### PR TITLE
ATSAM4N support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,9 @@ jobs:
         mcu: [
           # atsam4e
           atsam4e8c, atsam4e8e, atsam4e16c, atsam4e16e,
+          # atsam4n
+          atsam4n8a, atsam4n8b, atsam4n8c,
+          atsam4n16b, atsam4n16c,
           # atsam4s
           atsam4s2a, atsam4s2b, atsam4s2c,
           atsam4s4a, atsam4s4b, atsam4s4c,
@@ -30,7 +33,7 @@ jobs:
           toolchain: stable
           override: true
       - uses: actions-rs/toolchain@v1
-        if: ${{ contains(matrix.mcu, 'atsam4s') }}
+        if: ${{ contains(matrix.mcu, 'atsam4s') || contains(matrix.mcu, 'atsam4n') }}
         with:
           target: thumbv7em-none-eabi
           toolchain: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atsam4-hal"
-version = "0.1.11"
+version = "0.1.12"
 authors = ["John W. Terrell <john@coolpeoplenetworks.com>", "Jacob Alexander <haata@kiibohd.com>"]
 edition = "2018"
 description = "HAL for the ATSAM4 microcontrollers"
@@ -15,7 +15,6 @@ cortex-m = "0.7.2"
 cortex-m-rt = "0.6.13"
 embedded-hal = { version = "0.2.4", features = ["unproven"] }
 embedded-time = "0.10.1"
-lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 nb = "0.1.0"
 paste = "1.0"
 void = { version = "1.0.2", default-features = false }
@@ -26,6 +25,13 @@ atsam4e8c-pac = { version = "0.1.7", optional = true }
 atsam4e8e-pac = { version = "0.1.7", optional = true }
 atsam4e16c-pac = { version = "0.1.7", optional = true }
 atsam4e16e-pac = { version = "0.1.7", optional = true }
+
+# atsam4n
+atsam4n8a-pac = { version = "0.1.0", optional = true }
+atsam4n8b-pac = { version = "0.1.0", optional = true }
+atsam4n8c-pac = { version = "0.1.0", optional = true }
+atsam4n16b-pac = { version = "0.1.0", optional = true }
+atsam4n16c-pac = { version = "0.1.0", optional = true }
 
 # atsam4s
 atsam4s2a-pac = { version = "0.1.2", optional = true }
@@ -59,6 +65,14 @@ atsam4e8c = ["atsam4e", "atsam4e_c", "atsam4e8c-pac", "atsam4e8c-pac/rt"]
 atsam4e8e = ["atsam4e", "atsam4e_e", "atsam4e8e-pac", "atsam4e8e-pac/rt"]
 atsam4e16c = ["atsam4e", "atsam4e_c", "atsam4e16c-pac", "atsam4e16c-pac/rt"]
 atsam4e16e = ["atsam4e", "atsam4e_e", "atsam4e16e-pac", "atsam4e16e-pac/rt"]
+
+# atsam4n
+atsam4n = []
+atsam4n8a = ["atsam4n", "atsam4n8a-pac", "atsam4n8a-pac/rt"]
+atsam4n8b = ["atsam4n", "atsam4n8b-pac", "atsam4n8b-pac/rt"]
+atsam4n8c = ["atsam4n", "atsam4n8c-pac", "atsam4n8c-pac/rt"]
+atsam4n16b = ["atsam4n", "atsam4n16b-pac", "atsam4n16b-pac/rt"]
+atsam4n16c = ["atsam4n", "atsam4n16c-pac", "atsam4n16c-pac/rt"]
 
 # atsam4s
 atsam4s = []

--- a/src/chipid.rs
+++ b/src/chipid.rs
@@ -14,6 +14,7 @@ pub enum EmbeddedProcessor {
 #[derive(Clone, Copy, Debug)]
 pub enum Family {
     AtSam4e,
+    AtSam4n,
     AtSam4s,
 }
 
@@ -23,6 +24,12 @@ pub enum Model {
     AtSam4e8e,
     AtSam4e16c,
     AtSam4e16e,
+
+    AtSam4n8a,
+    AtSam4n8b,
+    AtSam4n8c,
+    AtSam4n16b,
+    AtSam4n16c,
 
     AtSam4s2a,
     AtSam4s2b,
@@ -191,6 +198,13 @@ impl ChipId {
 
             0x2997_0EE0 => (Some(Family::AtSam4s), Some(Model::AtSam4sd32b)),
             0x29A7_0EE0 => (Some(Family::AtSam4s), Some(Model::AtSam4sd32c)),
+            
+            0x293B_0AE0 => (Some(Family::AtSam4n), Some(Model::AtSam4n8a)),
+            0x294B_0AE0 => (Some(Family::AtSam4n), Some(Model::AtSam4n8b)),
+            0x295B_0AE0 => (Some(Family::AtSam4n), Some(Model::AtSam4n8c)),
+
+            0x2946_0CE0 => (Some(Family::AtSam4n), Some(Model::AtSam4n16b)),
+            0x2956_0CE0 => (Some(Family::AtSam4n), Some(Model::AtSam4n16c)),
 
             0xA3CC_0CE0 => match chip_id.exid.read().bits() {
                 0x0012_0209 => (Some(Family::AtSam4e), Some(Model::AtSam4e8c)),

--- a/src/chipid.rs
+++ b/src/chipid.rs
@@ -198,7 +198,7 @@ impl ChipId {
 
             0x2997_0EE0 => (Some(Family::AtSam4s), Some(Model::AtSam4sd32b)),
             0x29A7_0EE0 => (Some(Family::AtSam4s), Some(Model::AtSam4sd32c)),
-            
+
             0x293B_0AE0 => (Some(Family::AtSam4n), Some(Model::AtSam4n8a)),
             0x294B_0AE0 => (Some(Family::AtSam4n), Some(Model::AtSam4n8b)),
             0x295B_0AE0 => (Some(Family::AtSam4n), Some(Model::AtSam4n8c)),

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -167,9 +167,9 @@ fn setup_main_clock(pmc: &PMC, main_clock: MainClock) -> Hertz {
         MainClock::Crystal12Mhz => {
             switch_main_clock_to_external_12mhz(pmc);
 
-            // Set up the PLL for 96MHz operation (12 MHz * (8 / 1) = 96 MHz)
-            let multiplier: u16 = 8;
-            let divider: u8 = 1;
+            // Set up the PLL for 100MHz operation (12 MHz * (25 / 3) = 100 MHz)
+            let multiplier: u16 = 25;
+            let divider: u8 = 3;
             enable_plla_clock(pmc, multiplier, divider);
 
             // 0 = no prescaling

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -36,9 +36,7 @@ pub enum SlowClock {
 }
 
 pub fn get_master_clock_frequency() -> Hertz {
-    unsafe {
-        MASTER_CLOCK_FREQUENCY
-    }
+    unsafe { MASTER_CLOCK_FREQUENCY }
 }
 
 fn setup_slow_clock(supc: &SUPC, slow_clock: SlowClock) -> Hertz {
@@ -233,7 +231,7 @@ fn calculate_master_clock_frequency(pmc: &PMC) -> Hertz {
                     } else {
                         panic!("Unexpected value detected read from pmc.ckgr_mor.moscrcf")
                     }
-                },
+                }
             };
 
             let plla_clock_source: u8 = 2; // 2 = PLLA

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -19,6 +19,7 @@ static mut MASTER_CLOCK_FREQUENCY: Hertz = Hertz(0);
 // NOTE: More frequencies and crystals can be added
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MainClock {
+    #[cfg(not(feature = "atsam4n"))]
     RcOscillator4Mhz,  // USB Unsupported
     RcOscillator8Mhz,  // USB Unsupported
     RcOscillator12Mhz, // USB Unsupported
@@ -69,18 +70,6 @@ fn setup_main_clock(pmc: &PMC, main_clock: MainClock) -> Hertz {
 
             // Set up the PLL for 120Mhz operation (4Mhz RC * (30 / 1) = 120Mhz)
             let multiplier: u16 = 30;
-            let divider: u8 = 1;
-            enable_plla_clock(pmc, multiplier, divider);
-
-            // 0 = no prescaling
-            0
-        }
-        #[cfg(feature = "atsam4n")]
-        MainClock::RcOscillator4Mhz => {
-            switch_main_clock_to_fast_rc_4mhz(pmc);
-
-            // Set up the PLL for 100Mhz operation (4Mhz RC * (25 / 1) = 100Mhz)
-            let multiplier: u16 = 25;
             let divider: u8 = 1;
             enable_plla_clock(pmc, multiplier, divider);
 
@@ -367,6 +356,7 @@ fn change_main_clock_to_crystal(pmc: &PMC) {
         .modify(|_, w| w.key().passwd().moscrcen().clear_bit().moscsel().set_bit());
 }
 
+#[cfg(not(feature = "atsam4n"))]
 fn switch_main_clock_to_fast_rc_4mhz(pmc: &PMC) {
     enable_fast_rc_oscillator(pmc);
     wait_for_fast_rc_oscillator_to_stabilize(pmc);
@@ -396,6 +386,7 @@ fn enable_fast_rc_oscillator(pmc: &PMC) {
         .modify(|_, w| w.key().passwd().moscrcen().set_bit());
 }
 
+#[cfg(not(feature = "atsam4n"))]
 fn change_fast_rc_oscillator_to_4mhz(pmc: &PMC) {
     pmc.ckgr_mor
         .modify(|_, w| w.key().passwd().moscrcf()._4_mhz());

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -20,7 +20,7 @@ static mut MASTER_CLOCK_FREQUENCY: Hertz = Hertz(0);
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MainClock {
     #[cfg(not(feature = "atsam4n"))]
-    RcOscillator4Mhz,  // USB Unsupported
+    RcOscillator4Mhz, // USB Unsupported
     RcOscillator8Mhz,  // USB Unsupported
     RcOscillator12Mhz, // USB Unsupported
     Crystal12Mhz,      // USB Supported

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -103,9 +103,9 @@ fn setup_main_clock(pmc: &PMC, main_clock: MainClock) -> Hertz {
         MainClock::RcOscillator8Mhz => {
             switch_main_clock_to_fast_rc_8mhz(pmc);
 
-            // Set up the PLL for 80Mhz operation (8Mhz RC * (12 / 1) = 96Mhz)
-            let multiplier: u16 = 12;
-            let divider: u8 = 1;
+            // Set up the PLL for 100Mhz operation (8Mhz RC * (25 / 2) = 100Mhz)
+            let multiplier: u16 = 25;
+            let divider: u8 = 2;
             enable_plla_clock(pmc, multiplier, divider);
 
             // 0 = no prescaling
@@ -127,9 +127,9 @@ fn setup_main_clock(pmc: &PMC, main_clock: MainClock) -> Hertz {
         MainClock::RcOscillator12Mhz => {
             switch_main_clock_to_fast_rc_12mhz(pmc);
 
-            // Set up the PLL for 96Mhz operation (12Mhz RC * (8 / 1) = 96Mhz)
-            let multiplier: u16 = 8;
-            let divider: u8 = 1;
+            // Set up the PLL for 100Mhz operation (12Mhz RC * (25 / 3) = 100Mhz)
+            let multiplier: u16 = 25;
+            let divider: u8 = 3;
             enable_plla_clock(pmc, multiplier, divider);
 
             // 0 = no prescaling

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -57,7 +57,10 @@ impl Ports {
     pub fn new(
         _pioa: (PIOA, PioAClock<Enabled>),
         _piob: (PIOB, PioBClock<Enabled>),
-        #[cfg(any(feature = "atsam4n", feature = "atsam4s_c", feature = "atsam4e_e"))] _pioc: (PIOC, PioCClock<Enabled>),
+        #[cfg(any(feature = "atsam4n", feature = "atsam4s_c", feature = "atsam4e_e"))] _pioc: (
+            PIOC,
+            PioCClock<Enabled>,
+        ),
         #[cfg(feature = "atsam4e")] _piod: (PIOD, PioDClock<Enabled>),
         #[cfg(feature = "atsam4e_e")] _pioe: (PIOE, PioEClock<Enabled>),
     ) -> Self {

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -16,6 +16,12 @@ use {
     crate::pac::{pioc, pioe, PIOC, PIOE},
 };
 
+#[cfg(feature = "atsam4n")]
+use {
+    crate::clock::{Enabled, PioAClock, PioBClock, PioCClock},
+    crate::pac::{pioa, piob, pioc, PIOA, PIOB, PIOC},
+};
+
 #[cfg(feature = "atsam4s")]
 use {
     crate::clock::{Enabled, PioAClock, PioBClock},
@@ -39,7 +45,7 @@ pub trait GpioExt {
 pub struct Ports {
     pioa: PhantomData<(PIOA, PioAClock<Enabled>)>,
     piob: PhantomData<(PIOB, PioBClock<Enabled>)>,
-    #[cfg(any(feature = "atsam4s_c", feature = "atsam4e_e"))]
+    #[cfg(any(feature = "atsam4n", feature = "atsam4s_c", feature = "atsam4e_e"))]
     pioc: PhantomData<(PIOC, PioCClock<Enabled>)>,
     #[cfg(feature = "atsam4e")]
     piod: PhantomData<(PIOD, PioDClock<Enabled>)>,
@@ -51,7 +57,7 @@ impl Ports {
     pub fn new(
         _pioa: (PIOA, PioAClock<Enabled>),
         _piob: (PIOB, PioBClock<Enabled>),
-        #[cfg(any(feature = "atsam4s_c", feature = "atsam4e_e"))] _pioc: (PIOC, PioCClock<Enabled>),
+        #[cfg(any(feature = "atsam4n", feature = "atsam4s_c", feature = "atsam4e_e"))] _pioc: (PIOC, PioCClock<Enabled>),
         #[cfg(feature = "atsam4e")] _piod: (PIOD, PioDClock<Enabled>),
         #[cfg(feature = "atsam4e_e")] _pioe: (PIOE, PioEClock<Enabled>),
     ) -> Self {
@@ -59,7 +65,7 @@ impl Ports {
         Ports {
             pioa: PhantomData,
             piob: PhantomData,
-            #[cfg(any(feature = "atsam4s_c", feature = "atsam4e_e"))]
+            #[cfg(any(feature = "atsam4n", feature = "atsam4s_c", feature = "atsam4e_e"))]
             pioc: PhantomData,
             #[cfg(feature = "atsam4e")]
             piod: PhantomData,
@@ -128,7 +134,7 @@ macro_rules! pins {
             )+
             $(
                 /// Pin $pin_identC
-                #[cfg(any(feature = "atsam4s_c", feature = "atsam4e_e"))]
+                #[cfg(any(feature = "atsam4n", feature = "atsam4s_c", feature = "atsam4e_e"))]
                 pub $pin_identC: $PinTypeC<Input<Floating>>,
             )+
             $(
@@ -156,7 +162,7 @@ macro_rules! pins {
                         $pin_identB: $PinTypeB { _mode: PhantomData },
                     )+
                     $(
-                        #[cfg(any(feature = "atsam4s_c", feature = "atsam4e_e"))]
+                        #[cfg(any(feature = "atsam4n", feature = "atsam4s_c", feature = "atsam4e_e"))]
                         $pin_identC: $PinTypeC { _mode: PhantomData },
                     )+
                     $(
@@ -178,7 +184,7 @@ macro_rules! pins {
             pin!($PinTypeB, $pin_identB, $pin_noB, PIOB, piob);
         )+
         $(
-            #[cfg(any(feature = "atsam4s_c", feature = "atsam4e_e"))]
+            #[cfg(any(feature = "atsam4n", feature = "atsam4s_c", feature = "atsam4e_e"))]
             pin!($PinTypeC, $pin_identC, $pin_noC, PIOC, pioc);
         )+
         $(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,9 +24,6 @@
 // These errors seem to have been removed in nightly, so I suspect they may not stay.
 #![allow(clippy::upper_case_acronyms)]
 
-#[macro_use]
-extern crate lazy_static;
-
 pub extern crate embedded_hal as hal;
 pub use hal::digital::v2::*;
 
@@ -38,6 +35,17 @@ pub use atsam4e16e_pac as pac;
 pub use atsam4e8c_pac as pac;
 #[cfg(feature = "atsam4e8e")]
 pub use atsam4e8e_pac as pac;
+
+#[cfg(feature = "atsam4n8a")]
+pub use atsam4n8a_pac as pac;
+#[cfg(feature = "atsam4n8b")]
+pub use atsam4n8b_pac as pac;
+#[cfg(feature = "atsam4n8c")]
+pub use atsam4n8c_pac as pac;
+#[cfg(feature = "atsam4n16b")]
+pub use atsam4n16b_pac as pac;
+#[cfg(feature = "atsam4n16c")]
+pub use atsam4n16c_pac as pac;
 
 #[cfg(feature = "atsam4s2a")]
 pub use atsam4s2a_pac as pac;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,16 +36,16 @@ pub use atsam4e8c_pac as pac;
 #[cfg(feature = "atsam4e8e")]
 pub use atsam4e8e_pac as pac;
 
+#[cfg(feature = "atsam4n16b")]
+pub use atsam4n16b_pac as pac;
+#[cfg(feature = "atsam4n16c")]
+pub use atsam4n16c_pac as pac;
 #[cfg(feature = "atsam4n8a")]
 pub use atsam4n8a_pac as pac;
 #[cfg(feature = "atsam4n8b")]
 pub use atsam4n8b_pac as pac;
 #[cfg(feature = "atsam4n8c")]
 pub use atsam4n8c_pac as pac;
-#[cfg(feature = "atsam4n16b")]
-pub use atsam4n16b_pac as pac;
-#[cfg(feature = "atsam4n16c")]
-pub use atsam4n16c_pac as pac;
 
 #[cfg(feature = "atsam4s2a")]
 pub use atsam4s2a_pac as pac;

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -14,7 +14,7 @@ use {
 #[cfg(feature = "atsam4s")]
 use crate::gpio::{Pb2, Pb3};
 
-#[cfg(feature = "atsam4e")]
+#[cfg(any(feature = "atsam4e", feature = "atsam4n"))]
 use crate::gpio::{Pa5, Pa6, PfC};
 
 #[derive(Debug)]
@@ -187,16 +187,16 @@ macro_rules! uarts {
     }
 }
 
+#[cfg(any(feature = "atsam4e", feature = "atsam4n"))]
+uarts!(
+    Uart0: (UART0, Uart0, uart0, Pa9<PfA>, Pa10<PfA>),
+    Uart1: (UART1, Uart1, uart1, Pa5<PfC>, Pa6<PfC>),
+);
+
 #[cfg(feature = "atsam4s")]
 uarts!(
     Uart0: (UART0, Uart0, uart0, Pa9<PfA>, Pa10<PfA>),
     Uart1: (UART1, Uart1, uart1, Pb2<PfA>, Pb3<PfA>),
-);
-
-#[cfg(feature = "atsam4e")]
-uarts!(
-    Uart0: (UART0, Uart0, uart0, Pa9<PfA>, Pa10<PfA>),
-    Uart1: (UART1, Uart1, uart1, Pa5<PfC>, Pa6<PfC>),
 );
 
 pub type Serial0 = Uart0;


### PR DESCRIPTION
This PR added ATSAM4N support.   The clock setup is similar to how the ATSAM4E setup works.

Tests:
* Boots the "Blinky" sample in the sam_xplained repo on the sam4n_xplained_pro development board.