### PR TITLE
Adc merge

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/atsam4-rs/atsam4-hal"
 cast = { version = "0.2.2", default-features = false }
 cortex-m = "0.7.2"
 cortex-m-rt = "0.6.13"
+embedded-dma = "0.1.2"
 embedded-hal = { version = "0.2.4", features = ["unproven"] }
 embedded-time = "0.10.1"
 log = "0.4"

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -1,0 +1,1096 @@
+//! ADC Implementation
+//! Loosely based off of <https://github.com/atsamd-rs/atsamd/blob/master/hal/src/thumbv7em/adc.rs>
+//! NOTE: From ASF the following MCUs could be supported with this module
+//!       (sam/drivers/adc/adc.c)
+//!       atsam3s
+//!       atsam3n
+//!       atsam3u
+//!       atsam3xa
+//!       atsam4s (supported)
+//!       atsam4c
+//!       atsam4cp
+//!       atsam4cm
+//!
+//! TODO
+//! - Additional power saving (peripheral clock)
+//! - Automatic comparison
+
+use crate::clock::{AdcClock, Enabled};
+use crate::gpio::*;
+use crate::hal::adc::{Channel, OneShot};
+use crate::pac::ADC;
+use crate::pdc::*;
+use core::marker::PhantomData;
+use core::sync::atomic::{compiler_fence, Ordering};
+use cortex_m::singleton;
+use embedded_dma::StaticWriteBuffer;
+use embedded_time::rate::Hertz;
+
+#[derive(PartialEq, Copy, Clone, Debug)]
+pub enum Powersaving {
+    /// ADC core and reference voltage circuitry are kept on between conversions
+    Normal,
+    /// Voltage reference is kept on, but ADC core is disabled between conversions
+    FastWakeup,
+    /// ADC core and voltage reference are disabled between conversions
+    Sleep,
+}
+
+#[derive(PartialEq, Copy, Clone, Debug)]
+pub enum SingleEndedGain {
+    /// Single-ended gain = 1
+    Gain1x = 1,
+    /// Single-ended gain = 2
+    Gain2x = 2,
+    /// Single-ended gain = 4
+    Gain4x = 3,
+}
+
+/// An ADC where results are accessible via interrupt servicing.
+/// This is based off of atsamd-hal's InterruptAdc interface.
+/// It supports both single conversion and free running using an interrupt.
+///
+/// ```
+/// use atsam4_hal::adc::Adc;
+/// use atsam4_hal::clock::{ClockController, MainClock, SlowClock};
+/// use atsam4_hal::pac::Peripherals;
+///
+/// let peripherals = Peripherals::take().unwrap();
+/// let clocks = ClockController::new(
+///     peripherals.PMC,
+///     &peripherals.SUPC,
+///     &peripherals.EFC0,
+///     MainClock::Crystal12Mhz,
+///     SlowClock::RcOscillator32Khz,
+/// );
+/// let gpio_ports = Ports::new( // ATSAM4S8B
+///     (
+///         peripherals.PIOA,
+///         clocks.peripheral_clocks.pio_a.into_enabled_clock(),
+///     ),
+///     (
+///         peripherals.PIOB,
+///         clocks.peripheral_clocks.pio_b.into_enabled_clock(),
+///     ),
+/// );
+/// let mut pins = Pins::new(gpio_ports, &peripherals.MATRIX)
+///
+/// let mut adc = Adc::new(
+///     peripherals.ADC,
+///     clocks.peripheral_clocks.adc.into_enabled_clock(),
+/// );
+/// // Channels, gain and offset must be enabled and set before starting autocalibration
+/// adc.enable_channel(&mut pins.sense1); // pin sense1 = a17<ExFn, into_extra_function>
+/// adc.enable_channel(&mut pins.sense2); // pin sense2 = a18<ExFn, into_extra_function>
+/// adc.gain(&mut pins.sense1, SingleEndedGain::Gain4x);
+/// adc.offset(&mut pins.sense1, true);
+/// adc.autocalibration(true); // Waits for autocalibration to complete
+///
+/// // Convert to an InterruptAdc (either SingleConversion or FreeRunning)
+/// let mut adc: InterruptAdc<FreeRunning> = InterruptAdc::from(adc);
+/// // NOTE: You must both enable the channel and start the conversion for each pin
+/// //       Enabling the pins will start sampling; however, you must call start_conversion
+/// //       in order to enable the interrupt.
+/// adc.start_conversion(&mut pins.sense1);
+/// adc.start_conversion(&mut pins.sense2);
+///
+/// // RTIC interrupt. adc, sense1 and sense2 are the resource
+/// #[task(binds = ADC, resources = [adc, sense1, sense2])]
+/// fn adc(cx: adc::Context) {
+///     if let Some(values) = cx.resources.adc.service_interrupt_ready(cx.resources.sense1) {
+///         defmt::trace!("CH0 {}", values);
+///     }
+///     if let Some(values) = cx.resources.adc.service_interrupt_ready(cx.resources.sense2) {
+///         defmt::trace!("CH1 {}", values);
+///     }
+/// }
+/// ```
+pub struct InterruptAdc<C>
+where
+    C: ConversionMode,
+{
+    adc: Adc,
+    m: core::marker::PhantomData<C>,
+}
+
+/// Single shot ADC conversions
+/// Implements the embedded-hal ADC OneShot interface
+///
+/// ```
+/// use atsam4_hal::adc::Adc;
+/// use atsam4_hal::clock::{ClockController, MainClock, SlowClock};
+/// use atsam4_hal::pac::Peripherals;
+///
+/// let peripherals = Peripherals::take().unwrap();
+/// let clocks = ClockController::new(
+///     peripherals.PMC,
+///     &peripherals.SUPC,
+///     &peripherals.EFC0,
+///     MainClock::Crystal12Mhz,
+///     SlowClock::RcOscillator32Khz,
+/// );
+/// let gpio_ports = Ports::new(
+///     (
+///         peripherals.PIOA,
+///         clocks.peripheral_clocks.pio_a.into_enabled_clock(),
+///     ),
+///     (
+///         peripherals.PIOB,
+///         clocks.peripheral_clocks.pio_b.into_enabled_clock(),
+///     ),
+/// );
+/// let mut pins = Pins::new(gpio_ports, &peripherals.MATRIX)
+///
+/// let mut adc = Adc::new(
+///     peripherals.ADC,
+///     clocks.peripheral_clocks.adc.into_enabled_clock(),
+/// );
+/// // Channels, gain and offset must be enabled and set before starting autocalibration
+/// adc.enable_channel(&mut pins.sense1); // pin sense1 = a17<ExFn, into_extra_function>
+/// adc.gain(&mut pins.sense1, SingleEndedGain::Gain4x);
+/// adc.offset(&mut pins.sense1, true);
+/// adc.autocalibration(true); // Waits for autocalibration to complete
+///
+/// // Read a single value from the ADC channel
+/// let _value: u16 = adc.read(pins.sense1).unwrap();
+/// ```
+pub struct Adc {
+    adc: ADC,
+    clock: PhantomData<AdcClock<Enabled>>,
+}
+
+pub struct SingleConversion;
+pub struct FreeRunning;
+
+/// Describes how an interrupt-driven ADC should finalize the peripheral
+/// when the conversion completes.
+pub trait ConversionMode {
+    fn on_start(adc: &mut Adc);
+    fn on_complete<PIN: Channel<ADC, ID = u8>>(adc: &mut Adc, pin: &mut PIN);
+    fn on_stop<PIN: Channel<ADC, ID = u8>>(adc: &mut Adc, pin: &mut PIN);
+}
+
+impl Adc {
+    pub fn new(adc: ADC, clock: AdcClock<Enabled>) -> Self {
+        // Clear ADC write-protect
+        adc.wpmr
+            .modify(|_, w| w.wpkey().passwd().wpen().clear_bit());
+
+        /*
+         * Formula: ADCClock = MCK / ((PRESCAL+1) * 2)
+         *  MCK = 120MHz, PRESCAL = 2, then:
+         *  ADCClock = 120 / ((2+1) * 2) = 20MHz;
+         *  sam4s max ADCClock = 22 MHz
+         *
+         * Formula:
+         *     Startup  Time = startup value / ADCClock
+         *     Startup time = 64 / 20MHz = 3.2 us (4)
+         *     Startup time = 80 / 20MHz = 4 us (5)
+         *     Startup time = 96 / 20MHz = 4.8 us (6)
+         *     Startup time = 112 / 20MHz = 5.6 us (7)
+         *     Startup time = 512 / 20MHz = 25.6 us (8)
+         *     sam4s Min Startup Time = 4 us (max 12 us)
+         *
+         * adc_init(ADC, sysclk_get_cpu_hz(), 20000000, ADC_STARTUP_TIME_5);
+         */
+        // Reset the controller (simulates hardware reset)
+        adc.cr.write_with_zero(|w| w.swrst().set_bit());
+
+        // Reset mode register (set all fields to 0)
+        adc.mr.write_with_zero(|w| w);
+
+        // Reset PDC transfer
+        adc.ptcr
+            .write_with_zero(|w| w.rxtdis().set_bit().txtdis().set_bit());
+
+        // Setup prescalar and startup time
+        let prescaler = (clock.frequency().0 / (2 * Hertz(20000000).0) - 1) as u8;
+        adc.mr
+            .modify(|_, w| unsafe { w.prescal().bits(prescaler).startup().sut80() });
+
+        /* Set ADC timing.
+         * Formula:
+         *
+         *     Ttrack minimum = 0.054 * Zsource + 205
+         *     Ttrack minimum = 0.054 * 1.5k + 205 = 286 ns
+         *     Ttrack minimum = 0.054 * 10k + 205 = 745 ns
+         *     Ttrack minimum = 0.054 * 20k + 205 = 1285 ns
+         *     20MHz -> 50 ns * 15 cycles = 750 ns
+         *     750 ns > 286 ns -> Tracktim can be set to 0
+         *     750 ns > 745 ns -> Tracktim can be set to 0
+         *     750 ns < 1285 ns -> Tracktim can be set to 10 => 750 ns + 550 ns (10) = 1300 ns
+         *     See sam4s datasheet Figure 44-21 and Table 44-41 for details
+         *
+         *     Transfer Time = (TRANSFER * 2 + 3) / ADCClock
+         *     Tracking Time = (TRACKTIM + 1) / ADCClock
+         *     Settling Time = settling value / ADCClock
+         *
+         *     Hold Time
+         *     Transfer Time = (0 * 2 + 3) / 20MHz = 150 ns
+         *     Transfer Time = (1 * 2 + 3) / 20MHz = 250 ns
+         *     Transfer Time = (2 * 2 + 3) / 20MHz = 350 ns
+         *     Transfer Time = (3 * 2 + 3) / 20MHz = 450 ns
+         *
+         *     Track Time
+         *     Tracking Time = (0 + 1) / 20MHz = 50 ns
+         *     Tracking Time = (1 + 1) / 20MHz = 100 ns
+         *     Tracking Time = (2 + 1) / 20MHz = 150 ns
+         *     Tracking Time = (3 + 1) / 20MHz = 200 ns
+         *     Tracking Time = (4 + 1) / 20MHz = 250 ns
+         *     Tracking Time = (5 + 1) / 20MHz = 300 ns
+         *     Tracking Time = (6 + 1) / 20MHz = 350 ns
+         *     Tracking Time = (7 + 1) / 20MHz = 400 ns
+         *     Tracking Time = (8 + 1) / 20MHz = 450 ns
+         *     Tracking Time = (9 + 1) / 20MHz = 500 ns
+         *     Tracking Time = (10 + 1) / 20MHz = 550 ns
+         *     Tracking Time = (11 + 1) / 20MHz = 600 ns
+         *     Tracking Time = (12 + 1) / 20MHz = 650 ns
+         *     Tracking Time = (13 + 1) / 20MHz = 700 ns
+         *     Tracking Time = (14 + 1) / 20MHz = 750 ns
+         *     Tracking Time = (15 + 1) / 20MHz = 800 ns
+         *
+         *     Analog Settling Time
+         *     (TODO May need to tune this)
+         *     Settling Time = 3 / 20MHz = 150 ns (0)
+         *     Settling Time = 5 / 20MHz = 250 ns (1)
+         *     Settling Time = 9 / 20MHz = 450 ns (2)
+         *     Settling Time = 17 / 20MHz = 850 ns (3)
+         *
+         * const uint8_t tracking_time = 10;
+         * const uint8_t transfer_period = 2; // Recommended to be set to 2 by datasheet (42.7.2)
+         * adc_configure_timing(ADC, tracking_time, ADC_SETTLING_TIME_1, transfer_period);
+         */
+        let tracking_time = 10;
+        let transfer_period = 2;
+        adc.mr.modify(|_, w| unsafe {
+            w.transfer()
+                .bits(transfer_period)
+                .tracktim()
+                .bits(tracking_time)
+                .settling()
+                .ast5()
+        });
+
+        // Enable temperature sensor
+        adc.acr.modify(|_, w| w.tson().set_bit());
+
+        // Allow different gain/offset values for each channel
+        adc.mr.modify(|_, w| w.anach().allowed());
+
+        Self {
+            adc,
+            clock: PhantomData,
+        }
+    }
+
+    /// Enables channel number tags
+    /// Can be used for DMA to tag channel data.
+    /// Not necessary, as by default the ordering is by the enabled channels
+    /// or per the set sequence. Mainly for convenience.
+    pub fn enable_tags(&mut self) {
+        // Enable channel number tag for LCDR
+        self.adc.emr.modify(|_, w| w.tag().set_bit());
+    }
+
+    /// Disables channel number tags
+    pub fn disable_tags(&mut self) {
+        // Enable channel number tag for LCDR
+        self.adc.emr.modify(|_, w| w.tag().clear_bit());
+    }
+
+    /// Reterns a PIN-like reference for the temperature sensor
+    /// Used to enabled and start sampling of the temperature channel (15)
+    /// Cannot use pins as there is no pin reference.
+    /// ```
+    /// let mut adc = Adc::new(
+    ///     peripherals.ADC,
+    ///     clocks.peripheral_clocks.adc.into_enabled_clock(),
+    /// );
+    /// let temp_sensor = adc.temp_sensor();
+    /// adc.enable_channel(temp_sensor);
+    /// ```
+    pub fn temp_sensor(&mut self) -> &'static mut TempSensor {
+        singleton!(: TempSensor = TempSensor {}).unwrap()
+    }
+
+    /// Sets the channel read sequence
+    /// Used with the PDC
+    pub fn sequence(&mut self, channels: &[u8]) {
+        for (pos, ch) in channels.iter().enumerate() {
+            match pos {
+                0 => self.adc.seqr1.modify(|_, w| unsafe { w.usch1().bits(*ch) }),
+                1 => self.adc.seqr1.modify(|_, w| unsafe { w.usch2().bits(*ch) }),
+                2 => self.adc.seqr1.modify(|_, w| unsafe { w.usch3().bits(*ch) }),
+                3 => self.adc.seqr1.modify(|_, w| unsafe { w.usch4().bits(*ch) }),
+                4 => self.adc.seqr1.modify(|_, w| unsafe { w.usch5().bits(*ch) }),
+                5 => self.adc.seqr1.modify(|_, w| unsafe { w.usch6().bits(*ch) }),
+                6 => self.adc.seqr1.modify(|_, w| unsafe { w.usch7().bits(*ch) }),
+                7 => self.adc.seqr1.modify(|_, w| unsafe { w.usch8().bits(*ch) }),
+                8 => self.adc.seqr2.modify(|_, w| unsafe { w.usch9().bits(*ch) }),
+                9 => self
+                    .adc
+                    .seqr2
+                    .modify(|_, w| unsafe { w.usch10().bits(*ch) }),
+                10 => self
+                    .adc
+                    .seqr2
+                    .modify(|_, w| unsafe { w.usch11().bits(*ch) }),
+                11 => self
+                    .adc
+                    .seqr2
+                    .modify(|_, w| unsafe { w.usch12().bits(*ch) }),
+                12 => self
+                    .adc
+                    .seqr2
+                    .modify(|_, w| unsafe { w.usch13().bits(*ch) }),
+                13 => self
+                    .adc
+                    .seqr2
+                    .modify(|_, w| unsafe { w.usch14().bits(*ch) }),
+                14 => self
+                    .adc
+                    .seqr2
+                    .modify(|_, w| unsafe { w.usch15().bits(*ch) }),
+                _ => {
+                    panic!("Invalid sequence position: {}", pos);
+                }
+            }
+        }
+    }
+
+    /// Enable ADC sequencing
+    /// When enabled, the ADC channel sequence register is used to determine the ADC read order
+    pub fn enable_sequencing(&mut self) {
+        self.adc.mr.modify(|_, w| w.useq().set_bit());
+    }
+
+    /// Disable ADC sequencing
+    /// When disabled (default), the ADC channels are converted by (numerical) channel order
+    pub fn disable_sequencing(&mut self) {
+        self.adc.mr.modify(|_, w| w.useq().clear_bit());
+    }
+
+    /// Set the powersaving mode
+    /// By default set to Normal (no powersaving)
+    pub fn powersaving(&mut self, ps: Powersaving) {
+        match ps {
+            Powersaving::Normal => self.adc.mr.modify(|_, w| w.sleep().normal()),
+            Powersaving::FastWakeup => self.adc.mr.modify(|_, w| w.sleep().sleep().fwup().on()),
+            Powersaving::Sleep => self.adc.mr.modify(|_, w| w.sleep().sleep().fwup().off()),
+        }
+    }
+
+    /// Set channel single-ended gain
+    /// See Section 42.6.10 in ATSAM4S datasheet for details
+    /// NOTE: You must run calibration if gain settings are changed
+    pub fn gain<PIN: Channel<ADC, ID = u8>>(&mut self, _pin: &mut PIN, gain: SingleEndedGain) {
+        match PIN::channel() {
+            0 => self
+                .adc
+                .cgr
+                .modify(|_, w| unsafe { w.gain0().bits(gain as u8) }),
+            1 => self
+                .adc
+                .cgr
+                .modify(|_, w| unsafe { w.gain1().bits(gain as u8) }),
+            2 => self
+                .adc
+                .cgr
+                .modify(|_, w| unsafe { w.gain2().bits(gain as u8) }),
+            3 => self
+                .adc
+                .cgr
+                .modify(|_, w| unsafe { w.gain3().bits(gain as u8) }),
+            4 => self
+                .adc
+                .cgr
+                .modify(|_, w| unsafe { w.gain4().bits(gain as u8) }),
+            5 => self
+                .adc
+                .cgr
+                .modify(|_, w| unsafe { w.gain5().bits(gain as u8) }),
+            6 => self
+                .adc
+                .cgr
+                .modify(|_, w| unsafe { w.gain6().bits(gain as u8) }),
+            7 => self
+                .adc
+                .cgr
+                .modify(|_, w| unsafe { w.gain7().bits(gain as u8) }),
+            8 => self
+                .adc
+                .cgr
+                .modify(|_, w| unsafe { w.gain8().bits(gain as u8) }),
+            9 => self
+                .adc
+                .cgr
+                .modify(|_, w| unsafe { w.gain9().bits(gain as u8) }),
+            10 => self
+                .adc
+                .cgr
+                .modify(|_, w| unsafe { w.gain10().bits(gain as u8) }),
+            11 => self
+                .adc
+                .cgr
+                .modify(|_, w| unsafe { w.gain11().bits(gain as u8) }),
+            12 => self
+                .adc
+                .cgr
+                .modify(|_, w| unsafe { w.gain12().bits(gain as u8) }),
+            13 => self
+                .adc
+                .cgr
+                .modify(|_, w| unsafe { w.gain13().bits(gain as u8) }),
+            14 => self
+                .adc
+                .cgr
+                .modify(|_, w| unsafe { w.gain14().bits(gain as u8) }),
+            15 => self
+                .adc
+                .cgr
+                .modify(|_, w| unsafe { w.gain15().bits(gain as u8) }),
+            _ => {
+                panic!("Invalid channel: {}", PIN::channel());
+            }
+        }
+    }
+
+    /// Set voltage offset
+    /// See Section 42.6.10 in ATSAM4S datasheet for details
+    /// NOTE: You must run calibration if offset settings are changed
+    pub fn offset<PIN: Channel<ADC, ID = u8>>(&mut self, _pin: &mut PIN, offset: bool) {
+        match PIN::channel() {
+            0 => self.adc.cor.modify(|_, w| w.off0().bit(offset)),
+            1 => self.adc.cor.modify(|_, w| w.off1().bit(offset)),
+            2 => self.adc.cor.modify(|_, w| w.off2().bit(offset)),
+            3 => self.adc.cor.modify(|_, w| w.off3().bit(offset)),
+            4 => self.adc.cor.modify(|_, w| w.off4().bit(offset)),
+            5 => self.adc.cor.modify(|_, w| w.off5().bit(offset)),
+            6 => self.adc.cor.modify(|_, w| w.off6().bit(offset)),
+            7 => self.adc.cor.modify(|_, w| w.off7().bit(offset)),
+            8 => self.adc.cor.modify(|_, w| w.off8().bit(offset)),
+            9 => self.adc.cor.modify(|_, w| w.off9().bit(offset)),
+            10 => self.adc.cor.modify(|_, w| w.off10().bit(offset)),
+            11 => self.adc.cor.modify(|_, w| w.off11().bit(offset)),
+            12 => self.adc.cor.modify(|_, w| w.off12().bit(offset)),
+            13 => self.adc.cor.modify(|_, w| w.off13().bit(offset)),
+            14 => self.adc.cor.modify(|_, w| w.off14().bit(offset)),
+            15 => self.adc.cor.modify(|_, w| w.off15().bit(offset)),
+            _ => {
+                panic!("Invalid channel: {}", PIN::channel());
+            }
+        }
+    }
+
+    /// Autocalibration
+    /// Wait will block until autocalibration is complete
+    pub fn autocalibration(&mut self, wait: bool) {
+        self.adc.cr.write_with_zero(|w| w.autocal().set_bit());
+
+        if wait {
+            while !self.calibration_ready() {}
+        }
+    }
+
+    /// Checks if calibration is ready
+    /// Will return false if calibration is not ready, or calibration has not been requested
+    pub fn calibration_ready(&self) -> bool {
+        self.adc.isr.read().eocal().bit()
+    }
+
+    fn enable_freerunning(&mut self) {
+        self.adc.mr.modify(|_, w| w.freerun().on());
+    }
+
+    fn disable_freerunning(&mut self) {
+        self.adc.mr.modify(|_, w| w.freerun().off());
+    }
+
+    fn synchronous_convert<PIN: Channel<ADC, ID = u8>>(&mut self, _pin: &mut PIN) -> u16 {
+        self.start_conversion();
+        // Poll End-of-Conversions status bit
+        while !match PIN::channel() {
+            0 => self.adc.isr.read().eoc0().bit(),
+            1 => self.adc.isr.read().eoc1().bit(),
+            2 => self.adc.isr.read().eoc2().bit(),
+            3 => self.adc.isr.read().eoc3().bit(),
+            4 => self.adc.isr.read().eoc4().bit(),
+            5 => self.adc.isr.read().eoc5().bit(),
+            6 => self.adc.isr.read().eoc6().bit(),
+            7 => self.adc.isr.read().eoc7().bit(),
+            8 => self.adc.isr.read().eoc8().bit(),
+            9 => self.adc.isr.read().eoc9().bit(),
+            10 => self.adc.isr.read().eoc10().bit(),
+            11 => self.adc.isr.read().eoc11().bit(),
+            12 => self.adc.isr.read().eoc12().bit(),
+            13 => self.adc.isr.read().eoc13().bit(),
+            14 => self.adc.isr.read().eoc14().bit(),
+            15 => self.adc.isr.read().eoc15().bit(),
+            _ => {
+                panic!("Invalid channel: {}", PIN::channel());
+            }
+        } {}
+        // Read data register for the specified channel
+        self.adc.cdr[PIN::channel() as usize].read().data().bits()
+    }
+
+    fn start_conversion(&mut self) {
+        self.adc.cr.write_with_zero(|w| w.start().set_bit());
+    }
+
+    /// Enables the ADC pin channel
+    /// A channel, if used, must be enabled before autocalibration
+    /// This is needed to determine the various gain+offset settings used
+    /// See Section in 42.6.12 in the ATSAM4S datasheet for more details
+    pub fn enable_channel<PIN: Channel<ADC, ID = u8>>(&mut self, _pin: &mut PIN) {
+        match PIN::channel() {
+            0 => self.adc.cher.write_with_zero(|w| w.ch0().set_bit()),
+            1 => self.adc.cher.write_with_zero(|w| w.ch1().set_bit()),
+            2 => self.adc.cher.write_with_zero(|w| w.ch2().set_bit()),
+            3 => self.adc.cher.write_with_zero(|w| w.ch3().set_bit()),
+            4 => self.adc.cher.write_with_zero(|w| w.ch4().set_bit()),
+            5 => self.adc.cher.write_with_zero(|w| w.ch5().set_bit()),
+            6 => self.adc.cher.write_with_zero(|w| w.ch6().set_bit()),
+            7 => self.adc.cher.write_with_zero(|w| w.ch7().set_bit()),
+            8 => self.adc.cher.write_with_zero(|w| w.ch8().set_bit()),
+            9 => self.adc.cher.write_with_zero(|w| w.ch9().set_bit()),
+            10 => self.adc.cher.write_with_zero(|w| w.ch10().set_bit()),
+            11 => self.adc.cher.write_with_zero(|w| w.ch11().set_bit()),
+            12 => self.adc.cher.write_with_zero(|w| w.ch12().set_bit()),
+            13 => self.adc.cher.write_with_zero(|w| w.ch13().set_bit()),
+            14 => self.adc.cher.write_with_zero(|w| w.ch14().set_bit()),
+            15 => self.adc.cher.write_with_zero(|w| w.ch15().set_bit()),
+            _ => {
+                panic!("Invalid channel: {}", PIN::channel());
+            }
+        }
+    }
+
+    pub fn disable_channel<PIN: Channel<ADC, ID = u8>>(&mut self, _pin: &mut PIN) {
+        match PIN::channel() {
+            0 => self.adc.chdr.write_with_zero(|w| w.ch0().set_bit()),
+            1 => self.adc.chdr.write_with_zero(|w| w.ch1().set_bit()),
+            2 => self.adc.chdr.write_with_zero(|w| w.ch2().set_bit()),
+            3 => self.adc.chdr.write_with_zero(|w| w.ch3().set_bit()),
+            4 => self.adc.chdr.write_with_zero(|w| w.ch4().set_bit()),
+            5 => self.adc.chdr.write_with_zero(|w| w.ch5().set_bit()),
+            6 => self.adc.chdr.write_with_zero(|w| w.ch6().set_bit()),
+            7 => self.adc.chdr.write_with_zero(|w| w.ch7().set_bit()),
+            8 => self.adc.chdr.write_with_zero(|w| w.ch8().set_bit()),
+            9 => self.adc.chdr.write_with_zero(|w| w.ch9().set_bit()),
+            10 => self.adc.chdr.write_with_zero(|w| w.ch10().set_bit()),
+            11 => self.adc.chdr.write_with_zero(|w| w.ch11().set_bit()),
+            12 => self.adc.chdr.write_with_zero(|w| w.ch12().set_bit()),
+            13 => self.adc.chdr.write_with_zero(|w| w.ch13().set_bit()),
+            14 => self.adc.chdr.write_with_zero(|w| w.ch14().set_bit()),
+            15 => self.adc.chdr.write_with_zero(|w| w.ch15().set_bit()),
+            _ => {
+                panic!("Invalid channel: {}", PIN::channel());
+            }
+        }
+    }
+
+    /// Enables interrupts each channel
+    /// This does not use DRDY as DRDY under freerunning mode using interrupts
+    /// has the tendency to lose samples. Instead each channel interrupt is used instead
+    /// so that no samples are lost.
+    fn enable_interrupts<PIN: Channel<ADC, ID = u8>>(&mut self, _pin: &mut PIN) {
+        match PIN::channel() {
+            0 => self.adc.ier.write_with_zero(|w| w.eoc0().set_bit()),
+            1 => self.adc.ier.write_with_zero(|w| w.eoc1().set_bit()),
+            2 => self.adc.ier.write_with_zero(|w| w.eoc2().set_bit()),
+            3 => self.adc.ier.write_with_zero(|w| w.eoc3().set_bit()),
+            4 => self.adc.ier.write_with_zero(|w| w.eoc4().set_bit()),
+            5 => self.adc.ier.write_with_zero(|w| w.eoc5().set_bit()),
+            6 => self.adc.ier.write_with_zero(|w| w.eoc6().set_bit()),
+            7 => self.adc.ier.write_with_zero(|w| w.eoc7().set_bit()),
+            8 => self.adc.ier.write_with_zero(|w| w.eoc8().set_bit()),
+            9 => self.adc.ier.write_with_zero(|w| w.eoc9().set_bit()),
+            10 => self.adc.ier.write_with_zero(|w| w.eoc10().set_bit()),
+            11 => self.adc.ier.write_with_zero(|w| w.eoc11().set_bit()),
+            12 => self.adc.ier.write_with_zero(|w| w.eoc12().set_bit()),
+            13 => self.adc.ier.write_with_zero(|w| w.eoc13().set_bit()),
+            14 => self.adc.ier.write_with_zero(|w| w.eoc14().set_bit()),
+            15 => self.adc.ier.write_with_zero(|w| w.eoc15().set_bit()),
+            _ => {
+                panic!("Invalid channel: {}", PIN::channel());
+            }
+        }
+    }
+
+    /// Disables the interrupts.
+    fn disable_interrupts<PIN: Channel<ADC, ID = u8>>(&mut self, _pin: &mut PIN) {
+        match PIN::channel() {
+            0 => self.adc.idr.write_with_zero(|w| w.eoc0().set_bit()),
+            1 => self.adc.idr.write_with_zero(|w| w.eoc1().set_bit()),
+            2 => self.adc.idr.write_with_zero(|w| w.eoc2().set_bit()),
+            3 => self.adc.idr.write_with_zero(|w| w.eoc3().set_bit()),
+            4 => self.adc.idr.write_with_zero(|w| w.eoc4().set_bit()),
+            5 => self.adc.idr.write_with_zero(|w| w.eoc5().set_bit()),
+            6 => self.adc.idr.write_with_zero(|w| w.eoc6().set_bit()),
+            7 => self.adc.idr.write_with_zero(|w| w.eoc7().set_bit()),
+            8 => self.adc.idr.write_with_zero(|w| w.eoc8().set_bit()),
+            9 => self.adc.idr.write_with_zero(|w| w.eoc9().set_bit()),
+            10 => self.adc.idr.write_with_zero(|w| w.eoc10().set_bit()),
+            11 => self.adc.idr.write_with_zero(|w| w.eoc11().set_bit()),
+            12 => self.adc.idr.write_with_zero(|w| w.eoc12().set_bit()),
+            13 => self.adc.idr.write_with_zero(|w| w.eoc13().set_bit()),
+            14 => self.adc.idr.write_with_zero(|w| w.eoc14().set_bit()),
+            15 => self.adc.idr.write_with_zero(|w| w.eoc15().set_bit()),
+            _ => {
+                panic!("Invalid channel: {}", PIN::channel());
+            }
+        }
+    }
+
+    /// Checks for a ready value on the specified pin
+    fn service_interrupt_ready<PIN: Channel<ADC, ID = u8>>(
+        &mut self,
+        _pin: &mut PIN,
+    ) -> Option<u16> {
+        // If interrupt is not enable for this channel, don't bother checking
+        if !match PIN::channel() {
+            0 => self.adc.imr.read().eoc0().bit(),
+            1 => self.adc.imr.read().eoc1().bit(),
+            2 => self.adc.imr.read().eoc2().bit(),
+            3 => self.adc.imr.read().eoc3().bit(),
+            4 => self.adc.imr.read().eoc4().bit(),
+            5 => self.adc.imr.read().eoc5().bit(),
+            6 => self.adc.imr.read().eoc6().bit(),
+            7 => self.adc.imr.read().eoc7().bit(),
+            8 => self.adc.imr.read().eoc8().bit(),
+            9 => self.adc.imr.read().eoc9().bit(),
+            10 => self.adc.imr.read().eoc10().bit(),
+            11 => self.adc.imr.read().eoc11().bit(),
+            12 => self.adc.imr.read().eoc12().bit(),
+            13 => self.adc.imr.read().eoc13().bit(),
+            14 => self.adc.imr.read().eoc14().bit(),
+            15 => self.adc.imr.read().eoc15().bit(),
+            _ => {
+                panic!("Invalid channel: {}", PIN::channel());
+            }
+        } {
+            return None;
+        }
+
+        // Check to see if the channel is ready before reading
+        if match PIN::channel() {
+            0 => self.adc.isr.read().eoc0().bit(),
+            1 => self.adc.isr.read().eoc1().bit(),
+            2 => self.adc.isr.read().eoc2().bit(),
+            3 => self.adc.isr.read().eoc3().bit(),
+            4 => self.adc.isr.read().eoc4().bit(),
+            5 => self.adc.isr.read().eoc5().bit(),
+            6 => self.adc.isr.read().eoc6().bit(),
+            7 => self.adc.isr.read().eoc7().bit(),
+            8 => self.adc.isr.read().eoc8().bit(),
+            9 => self.adc.isr.read().eoc9().bit(),
+            10 => self.adc.isr.read().eoc10().bit(),
+            11 => self.adc.isr.read().eoc11().bit(),
+            12 => self.adc.isr.read().eoc12().bit(),
+            13 => self.adc.isr.read().eoc13().bit(),
+            14 => self.adc.isr.read().eoc14().bit(),
+            15 => self.adc.isr.read().eoc15().bit(),
+            _ => {
+                panic!("Invalid channel: {}", PIN::channel());
+            }
+        } {
+            Some(self.adc.cdr[PIN::channel() as usize].read().data().bits())
+        } else {
+            None
+        }
+    }
+}
+
+impl ConversionMode for SingleConversion {
+    fn on_start(_adc: &mut Adc) {}
+
+    fn on_complete<PIN: Channel<ADC, ID = u8>>(adc: &mut Adc, pin: &mut PIN) {
+        adc.disable_interrupts(pin);
+    }
+
+    fn on_stop<PIN: Channel<ADC, ID = u8>>(_adc: &mut Adc, _pin: &mut PIN) {}
+}
+
+impl ConversionMode for FreeRunning {
+    fn on_start(adc: &mut Adc) {
+        adc.enable_freerunning();
+    }
+
+    fn on_complete<PIN: Channel<ADC, ID = u8>>(_adc: &mut Adc, _pin: &mut PIN) {}
+
+    fn on_stop<PIN: Channel<ADC, ID = u8>>(adc: &mut Adc, pin: &mut PIN) {
+        adc.disable_interrupts(pin);
+        adc.disable_freerunning();
+    }
+}
+
+impl<C> InterruptAdc<C>
+where
+    C: ConversionMode,
+{
+    pub fn service_interrupt_ready<PIN: Channel<ADC, ID = u8>>(
+        &mut self,
+        pin: &mut PIN,
+    ) -> Option<u16> {
+        if let Some(res) = self.adc.service_interrupt_ready(pin) {
+            C::on_complete(&mut self.adc, pin);
+            Some(res)
+        } else {
+            None
+        }
+    }
+
+    /// Starts conversion sampling on specified pin
+    /// NOTE: You must enable the channel first before starting the conversion
+    ///       If you do not start the conversion on pins that have been enabled
+    ///       those pins will read ADC values but will not trigger an interrupt.
+    pub fn start_conversion<PIN: Channel<ADC, ID = u8>>(&mut self, pin: &mut PIN) {
+        C::on_start(&mut self.adc);
+        self.adc.enable_interrupts(pin);
+        self.adc.start_conversion();
+    }
+
+    pub fn stop_conversion<PIN: Channel<ADC, ID = u8>>(&mut self, pin: &mut PIN) {
+        C::on_stop(&mut self.adc, pin);
+    }
+
+    /// Reverts the InterruptAdc back to Adc
+    pub fn revert(self) -> Adc {
+        self.adc
+    }
+}
+
+impl<C> From<Adc> for InterruptAdc<C>
+where
+    C: ConversionMode,
+{
+    fn from(adc: Adc) -> Self {
+        Self {
+            adc,
+            m: PhantomData {},
+        }
+    }
+}
+
+impl<WORD, PIN> OneShot<ADC, WORD, PIN> for Adc
+where
+    WORD: From<u16>,
+    PIN: Channel<ADC, ID = u8>,
+{
+    type Error = ();
+
+    fn read(&mut self, pin: &mut PIN) -> nb::Result<WORD, Self::Error> {
+        // Trigger single shot
+        let result = self.synchronous_convert(pin);
+        Ok(result.into())
+    }
+}
+
+macro_rules! adc_pins {
+    (
+        $(
+            $PinId:ident: ($CHAN:literal),
+        )+
+    ) => {
+        $(
+            impl Channel<ADC> for $PinId<ExFn> {
+               type ID = u8;
+               fn channel() -> u8 { $CHAN }
+            }
+        )+
+    }
+}
+
+#[cfg(feature = "atsam4s")]
+adc_pins! {
+    Pa17: (0),
+    Pa18: (1),
+    Pa19: (2),
+    Pa20: (3),
+    Pb0: (4),
+    Pb1: (5),
+    Pb2: (6),
+    Pb3: (7),
+}
+
+#[cfg(any(feature = "atsam4s_b", feature = "atsam4s_c"))]
+adc_pins! {
+    Pa21: (8),
+    Pa22: (9),
+}
+
+#[cfg(feature = "atsam4s_c")]
+adc_pins! {
+    Pc13: (10),
+    Pc15: (11),
+    Pc12: (12),
+    Pc29: (13),
+    Pc30: (14),
+}
+
+/// Channel 15 is reserved for the temperature sensor
+#[cfg(feature = "atsam4s")]
+pub struct TempSensor {}
+
+#[cfg(feature = "atsam4s")]
+impl Channel<ADC> for TempSensor {
+    type ID = u8;
+    fn channel() -> u8 {
+        15
+    }
+}
+
+// Setup PDC Rx functionality
+pdc_rx! { Adc: adc }
+
+impl Adc {
+    /// Configures the ADC with PDC in single sequence mode
+    /// This will take a single sample of all the enable channels.
+    /// If sequence() has been set, then only the channels in the sequence will
+    /// be read.
+    ///
+    /// Since this is a single capture, the buffer used must be equal to the number
+    /// of channels going to be read (a smaller buffer would also work, but doesn't really
+    /// make sense). If the buffer is too large, the DMA transfer will not complete
+    /// and wait for the next ADC conversion event.
+    ///
+    /// Polling example
+    /// ```
+    /// let mut adc = Adc::new(
+    ///     cx.device.ADC,
+    ///     clocks.peripheral_clocks.adc.into_enabled_clock(),
+    /// );
+    ///
+    /// // Enable 3 channels
+    /// adc.enable_channel(&mut pins.sense1);
+    /// adc.enable_channel(&mut pins.sense2);
+    /// adc.enable_channel(&mut pins.sense3);
+    ///
+    /// // Enable DMA mode
+    /// let adc = adc.with_pdc();
+    ///
+    /// // Note that the buffer size is 3 and 3 channels were enabled
+    /// let buf = singleton!(: [u16; 4] = [0; 4]).unwrap();
+    ///
+    /// // Read and wait for the result
+    /// let (buf, adc) = adc.read(buf).wait();
+    /// defmt::trace!("DMA BUF: {}", buf);
+    ///
+    /// // Revert AdcDma<SingleSequence> back to Adc
+    /// let adc = adc.revert();
+    /// ```
+    ///
+    /// Interrupt example (RTIC)
+    /// ```
+    /// #[local]
+    /// struct Local {
+    ///     adc: Option<Transfer<W, &'static mut [u16; 6], RxDma<AdcPayload<SingleSequence>>>>,
+    /// }
+    ///
+    /// #[init(local = [adc_buf: [u16; 3] = [0; 3]])]
+    /// fn init(mut cx: init::Context) -> (Shared, Local, init::Monotonics) {
+    ///     let mut adc = Adc::new(
+    ///         cx.device.ADC,
+    ///         clocks.peripheral_clocks.adc.into_enabled_clock(),
+    ///     );
+    ///
+    ///     // Enable 3 channels
+    ///     adc.enable_channel(&mut pins.sense1);
+    ///     adc.enable_channel(&mut pins.sense2);
+    ///     adc.enable_channel(&mut pins.sense3);
+    ///
+    ///     // Enable DMA mode
+    ///     let adc = adc.with_pdc();
+    ///     (
+    ///         Shared {},
+    ///         Local {
+    ///             adc: Some(adc.read(cx.local.adc_buf)),
+    ///         },
+    ///         init::Monotonics {},
+    ///     )
+    /// }
+    ///
+    /// #[task(binds = ADC, local = [adc])]
+    /// fn adc(cx: adc::Context) {
+    ///     let (buf, adc) = cx.local.adc.take().unwrap().wait();
+    ///     defmt::trace!("DMA BUF: {}", buf);
+    ///     cx.local.adc.replace(adc.read(buf));
+    /// }
+    /// ```
+    pub fn with_pdc(self) -> AdcDma<SingleSequence> {
+        let payload = AdcPayload {
+            adc: self,
+            _mode: PhantomData,
+        };
+        RxDma { payload }
+    }
+
+    /// Configures the ADC with PDC in single sequence mode
+    /// This will take a single sample of all the enable channels.
+    /// If sequence() has been set, then only the channels in the sequence will
+    /// be read.
+    ///
+    /// Since this is a continous capture (e.g. freerunning), the buffer size may be any
+    /// size and the DMA transfer will complete once the buffer is full.
+    /// It is recommended to make the buffer a multiple of the number of channels enabled
+    /// (or number of channels used in the sequence).
+    ///
+    /// Polling example
+    /// ```
+    /// let mut adc = Adc::new(
+    ///     cx.device.ADC,
+    ///     clocks.peripheral_clocks.adc.into_enabled_clock(),
+    /// );
+    ///
+    /// // Enable 3 channels
+    /// adc.enable_channel(&mut pins.sense1);
+    /// adc.enable_channel(&mut pins.sense2);
+    /// adc.enable_channel(&mut pins.sense3);
+    ///
+    /// // Reorder sequence (by default, the channel numbers dictate the order)
+    /// adc.sequence(&mut [2, 1, 0]);
+    /// adc.enable_sequencing();
+    ///
+    /// // Enable DMA mode
+    /// let adc = adc.with_continuous_pdc();
+    ///
+    /// // Note that the buffer size is 6 and 3 channels were enabled
+    /// // Since we're running in freerunning mode the entire will fill up before
+    /// // the PDC notes completion.
+    /// let buf = singleton!(: [u16; 6] = [0; 6]).unwrap();
+    ///
+    /// // Read and wait for the result
+    /// let (buf, adc) = adc.read(buf).wait();
+    /// defmt::trace!("DMA BUF: {}", buf);
+    ///
+    /// // Revert AdcDma<Continuous> back to Adc
+    /// let adc = adc.revert();
+    /// ```
+    ///
+    /// Interrupt example (RTIC)
+    /// ```
+    /// #[local]
+    /// struct Local {
+    ///     adc: Option<Transfer<W, &'static mut [u16; 6], RxDma<AdcPayload<Continuous>>>>,
+    /// }
+    ///
+    /// #[init(local = [adc_buf: [u16; 6] = [0; 6]])]
+    /// fn init(mut cx: init::Context) -> (Shared, Local, init::Monotonics) {
+    ///     let mut adc = Adc::new(
+    ///         cx.device.ADC,
+    ///         clocks.peripheral_clocks.adc.into_enabled_clock(),
+    ///     );
+    ///
+    ///     // Enable 3 channels
+    ///     adc.enable_channel(&mut pins.sense1);
+    ///     adc.enable_channel(&mut pins.sense2);
+    ///     adc.enable_channel(&mut pins.sense3);
+    ///
+    ///     // Reorder sequence (by default, the channel numbers dictate the order)
+    ///     adc.sequence(&mut [2, 1, 0]);
+    ///     adc.enable_sequencing();
+    ///
+    ///     // Enable DMA mode
+    ///     let adc = adc.with_continuous_pdc();
+    ///     (
+    ///         Shared {},
+    ///         Local {
+    ///             adc: Some(adc.read(cx.local.adc_buf)),
+    ///         },
+    ///         init::Monotonics {},
+    ///     )
+    /// }
+    ///
+    /// #[task(binds = ADC, local = [adc])]
+    /// fn adc(cx: adc::Context) {
+    ///     let (buf, adc) = cx.local.adc.take().unwrap().wait();
+    ///     defmt::trace!("DMA BUF: {}", buf);
+    ///     cx.local.adc.replace(adc.read(buf));
+    /// }
+    /// ```
+    pub fn with_continuous_pdc(self) -> AdcDma<Continuous> {
+        let payload = AdcPayload {
+            adc: self,
+            _mode: PhantomData,
+        };
+        RxDma { payload }
+    }
+}
+
+/// Continuous mode
+pub struct Continuous;
+/// SingleSequence mode
+pub struct SingleSequence;
+
+pub struct AdcPayload<MODE> {
+    adc: Adc,
+    _mode: PhantomData<MODE>,
+}
+
+pub type AdcDma<MODE> = RxDma<AdcPayload<MODE>>;
+
+impl<MODE> AdcDma<MODE>
+where
+    Self: TransferPayload,
+{
+    /// Reverts the AdcDma back to Adc
+    pub fn revert(mut self) -> Adc {
+        // Disable PDC in case it is still enabled
+        self.payload.adc.stop_rx_pdc();
+
+        self.payload.adc
+    }
+}
+
+impl<MODE> Receive for AdcDma<MODE> {
+    type TransmittedWord = u16;
+}
+
+impl<B, MODE> ReadDma<B, u16> for AdcDma<MODE>
+where
+    Self: TransferPayload,
+    B: StaticWriteBuffer<Word = u16>,
+{
+    /// Assigns the buffer, enables PDC and starts ADC conversion
+    fn read(mut self, mut buffer: B) -> Transfer<W, B, Self> {
+        // NOTE(unsafe) We own the buffer now and we won't call other `&mut` on it
+        // until the end of the transfer.
+        let (ptr, len) = unsafe { buffer.static_write_buffer() };
+        self.payload.adc.set_receive_address(ptr as u32);
+        self.payload.adc.set_receive_counter(len as u16);
+
+        compiler_fence(Ordering::Release);
+        self.start();
+
+        Transfer::w(buffer, self)
+    }
+}
+
+impl TransferPayload for AdcDma<SingleSequence> {
+    fn start(&mut self) {
+        self.payload.adc.start_rx_pdc();
+        self.payload.adc.start_conversion(); // Start ADC conversions
+    }
+    fn stop(&mut self) {
+        self.payload.adc.stop_rx_pdc();
+    }
+    fn in_progress(&self) -> bool {
+        self.payload.adc.rx_in_progress()
+    }
+}
+
+impl TransferPayload for AdcDma<Continuous> {
+    fn start(&mut self) {
+        self.payload.adc.start_rx_pdc();
+        self.payload.adc.enable_freerunning();
+        self.payload.adc.start_conversion(); // Start ADC conversions
+    }
+    fn stop(&mut self) {
+        self.payload.adc.disable_freerunning();
+        self.payload.adc.stop_rx_pdc();
+    }
+    fn in_progress(&self) -> bool {
+        self.payload.adc.rx_in_progress()
+    }
+}

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -192,13 +192,13 @@ fn setup_main_clock(pmc: &PMC, main_clock: MainClock) -> Hertz {
             0
         }
     };
-    wait_for_main_clock_ready(&pmc);
+    wait_for_main_clock_ready(pmc);
 
-    wait_for_plla_lock(&pmc);
+    wait_for_plla_lock(pmc);
 
     switch_master_clock_to_plla(pmc, prescaler);
 
-    calculate_master_clock_frequency(&pmc)
+    calculate_master_clock_frequency(pmc)
 }
 
 fn calculate_master_clock_frequency(pmc: &PMC) -> Hertz {
@@ -913,6 +913,10 @@ impl ClockController {
         main_clock: MainClock,
         slow_clock: SlowClock,
     ) -> Self {
+        // Make sure write protection has been disabled
+        pmc.pmc_wpmr
+            .modify(|_, w| w.wpkey().passwd().wpen().clear_bit());
+
         set_flash_wait_states_to_maximum(
             #[cfg(any(feature = "atsam4e", feature = "atsam4n"))]
             efc,

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -98,6 +98,8 @@ pub struct PfC;
 pub struct PfD;
 /// System Function
 pub struct SysFn;
+/// Extra Function
+pub struct ExFn;
 
 /// Floating Input
 pub struct Floating;
@@ -113,11 +115,11 @@ pub struct OpenDrain;
 
 macro_rules! pins {
     ([
-        $($PinTypeA:ident: ($pin_identA:ident, $pin_noA:expr),)*
+        $($PinTypeA:ident: ($pin_identA:ident, $pin_noA:expr, $extfnA:ident),)*
     ],[
-        $($PinTypeB:ident: ($pin_identB:ident, $pin_noB:expr, $sysioB:ident),)*
+        $($PinTypeB:ident: ($pin_identB:ident, $pin_noB:expr, $extfnB:ident, $sysioB:ident),)*
     ],[
-        $($PinTypeC:ident: ($pin_identC:ident, $pin_noC:expr),)*
+        $($PinTypeC:ident: ($pin_identC:ident, $pin_noC:expr, $extfnC:ident),)*
     ],[
         $($PinTypeD:ident: ($pin_identD:ident, $pin_noD:expr),)*
     ],[
@@ -181,16 +183,20 @@ macro_rules! pins {
         $(
             pin!($PinTypeA, $pin_identA, $pin_noA, PIOA, pioa);
             pin_sysio!($PinTypeA, $pin_noA, false);
+            pin_extrafn!($PinTypeA, $extfnA);
         )*
         $(
             pin!($PinTypeB, $pin_identB, $pin_noB, PIOB, piob);
             pin_sysio!($PinTypeB, $pin_noB, $sysioB);
+            pin_extrafn!($PinTypeB, $extfnB);
         )*
         $(
             #[cfg(any(feature = "atsam4n_c", feature = "atsam4s_c", feature = "atsam4e_e"))]
             pin!($PinTypeC, $pin_identC, $pin_noC, PIOC, pioc);
             #[cfg(any(feature = "atsam4n_c", feature = "atsam4s_c", feature = "atsam4e_e"))]
             pin_sysio!($PinTypeC, $pin_noC, false);
+            #[cfg(any(feature = "atsam4n_c", feature = "atsam4s_c", feature = "atsam4e_e"))]
+            pin_extrafn!($PinTypeC, $extfnC);
         )*
         $(
             #[cfg(feature = "atsam4e")]
@@ -205,6 +211,27 @@ macro_rules! pins {
             pin_sysio!($PinTypeE, $pin_noE, false);
         )*
     };
+}
+
+/// Extra Function
+/// These function do not do any setup, they are solely for assigning Rust ownership to specific
+/// pins based on their intended use. To simplify, all functions (even if there are multiple)
+/// are defined as ExFn.
+macro_rules! pin_extrafn {
+    (
+        $PinType:ident,
+        true
+    ) => {
+        impl<MODE> $PinType<MODE> {
+            pub fn into_extra_function(self, _matrix: &MATRIX) -> $PinType<ExFn> {
+                $PinType { _mode: PhantomData }
+            }
+        }
+    };
+    (
+        $PinType:ident,
+        false
+    ) => {};
 }
 
 /// System I/O Configuration setup
@@ -617,90 +644,90 @@ macro_rules! pin {
 
 #[cfg(feature = "atsam4e")]
 pins!([
-    Pa0: (pa0, 0),
-    Pa1: (pa1, 1),
-    Pa2: (pa2, 2),
-    Pa3: (pa3, 3),
-    Pa4: (pa4, 4),
-    Pa5: (pa5, 5),
-    Pa6: (pa6, 6),
-    Pa7: (pa7, 7),
-    Pa8: (pa8, 8),
-    Pa9: (pa9, 9),
-    Pa10: (pa10, 10),
-    Pa11: (pa11, 11),
-    Pa12: (pa12, 12),
-    Pa13: (pa13, 13),
-    Pa14: (pa14, 14),
-    Pa15: (pa15, 15),
-    Pa16: (pa16, 16),
-    Pa17: (pa17, 17),
-    Pa18: (pa18, 18),
-    Pa19: (pa19, 19),
-    Pa20: (pa20, 20),
-    Pa21: (pa21, 21),
-    Pa22: (pa22, 22),
-    Pa23: (pa23, 23),
-    Pa24: (pa24, 24),
-    Pa25: (pa25, 25),
-    Pa26: (pa26, 26),
-    Pa27: (pa27, 27),
-    Pa28: (pa28, 28),
-    Pa29: (pa29, 29),
-    Pa30: (pa30, 30),
-    Pa31: (pa31, 31),
+    Pa0: (pa0, 0, true), // WKUP0
+    Pa1: (pa1, 1, true), // WKUP1
+    Pa2: (pa2, 2, true), // WKUP2
+    Pa3: (pa3, 3, false),
+    Pa4: (pa4, 4, true), // WKUP3
+    Pa5: (pa5, 5, true), // WKUP4
+    Pa6: (pa6, 6, false),
+    Pa7: (pa7, 7, false),
+    Pa8: (pa8, 8, true), // WKUP5
+    Pa9: (pa9, 9, true), // WKUP6
+    Pa10: (pa10, 10, false),
+    Pa11: (pa11, 11, true), // WKUP7
+    Pa12: (pa12, 12, false),
+    Pa13: (pa13, 13, false),
+    Pa14: (pa14, 14, true), // WKUP8
+    Pa15: (pa15, 15, true), // WKUP14/PIODCEN1
+    Pa16: (pa16, 16, true), // WKUP15/PIODCEN2
+    Pa17: (pa17, 17, true), // AFE0_AD0
+    Pa18: (pa18, 18, true), // AFE0_AD1
+    Pa19: (pa19, 19, true), // AFE0_AD2/WKUP9
+    Pa20: (pa20, 20, true), // AFE0_AD3/WKUP10
+    Pa21: (pa21, 21, true), // AFE1_AD2
+    Pa22: (pa22, 22, true), // AFE1_AD3
+    Pa23: (pa23, 23, true), // PIODCCLK
+    Pa24: (pa24, 24, true), // PIODC0
+    Pa25: (pa25, 25, true), // PIODC1
+    Pa26: (pa26, 26, true), // PIODC2
+    Pa27: (pa27, 27, true), // PIODC3
+    Pa28: (pa28, 28, true), // PIODC4
+    Pa29: (pa29, 29, true), // PIODC5
+    Pa30: (pa30, 30, true), // WKUP11/PIODC6
+    Pa31: (pa31, 31, true), // PIODC7
 ],[
-    Pb0: (pb0, 0, false),
-    Pb1: (pb1, 1, false),
-    Pb2: (pb2, 2, false),
-    Pb3: (pb3, 3, false),
-    Pb4: (pb4, 4, true), // SYSIO4 - TDI
-    Pb5: (pb5, 5, true), // SYSIO5 - TDO/TRACESWO
-    Pb6: (pb6, 6, true), // SYSIO6 - TMS/SWDIO
-    Pb7: (pb7, 7, true), // SYSIO7 - TCK/SWCLK
-    Pb8: (pb8, 8, false),
-    Pb9: (pb9, 9, false),
-    Pb10: (pb10, 10, true), // SYSIO10 - DDM
-    Pb11: (pb11, 11, true), // SYSIO11 - DDP
-    Pb12: (pb12, 12, true), // SYSIO12 - ERASE
-    Pb13: (pb13, 13, false),
-    Pb14: (pb14, 14, false),
+    Pb0: (pb0, 0, true, false), // AFE0_AD4/RTCOUT0
+    Pb1: (pb1, 1, true, false), // AFE0_AD5/RTCOUT1
+    Pb2: (pb2, 2, true, false), // AFE1_AD0/WKUP12
+    Pb3: (pb3, 3, true, false), // AFE1_AD1
+    Pb4: (pb4, 4, false, true), // | SYSIO4 - TDI
+    Pb5: (pb5, 5, true, true), // WKUP13 | SYSIO5 - TDO/TRACESWO
+    Pb6: (pb6, 6, false, true), // | SYSIO6 - TMS/SWDIO
+    Pb7: (pb7, 7, false, true), // | SYSIO7 - TCK/SWCLK
+    Pb8: (pb8, 8, false, false),
+    Pb9: (pb9, 9, false, false),
+    Pb10: (pb10, 10, false, true), // | SYSIO10 - DDM
+    Pb11: (pb11, 11, false, true), // | SYSIO11 - DDP
+    Pb12: (pb12, 12, false, true), // | SYSIO12 - ERASE
+    Pb13: (pb13, 13, true, false), // DAC0
+    Pb14: (pb14, 14, true, false), // DAC1
 
     // PB15-31 do not exist.
 ],
 [
-    Pc0: (pc0, 0),
-    Pc1: (pc1, 1),
-    Pc2: (pc2, 2),
-    Pc3: (pc3, 3),
-    Pc4: (pc4, 4),
-    Pc5: (pc5, 5),
-    Pc6: (pc6, 6),
-    Pc7: (pc7, 7),
-    Pc8: (pc8, 8),
-    Pc9: (pc9, 9),
-    Pc10: (pc10, 10),
-    Pc11: (pc11, 11),
-    Pc12: (pc12, 12),
-    Pc13: (pc13, 13),
-    Pc14: (pc14, 14),
-    Pc15: (pc15, 15),
-    Pc16: (pc16, 16),
-    Pc17: (pc17, 17),
-    Pc18: (pc18, 18),
-    Pc19: (pc19, 19),
-    Pc20: (pc20, 20),
-    Pc21: (pc21, 21),
-    Pc22: (pc22, 22),
-    Pc23: (pc23, 23),
-    Pc24: (pc24, 24),
-    Pc25: (pc25, 25),
-    Pc26: (pc26, 26),
-    Pc27: (pc27, 27),
-    Pc28: (pc28, 28),
-    Pc29: (pc29, 29),
-    Pc30: (pc30, 30),
-    Pc31: (pc31, 31),
+    Pc0: (pc0, 0, true), // AFE0_AD14
+    Pc1: (pc1, 1, true), // AFE1_AD4
+    Pc2: (pc2, 2, true), // AFE1_AD5
+    Pc3: (pc3, 3, true), // AFE1_AD6
+    Pc4: (pc4, 4, true), // AFE1_AD7
+    Pc5: (pc5, 5, false),
+    Pc6: (pc6, 6, false),
+    Pc7: (pc7, 7, false),
+    Pc8: (pc8, 8, false),
+    Pc9: (pc9, 9, false),
+    Pc10: (pc10, 10, false),
+    Pc11: (pc11, 11, false),
+    Pc12: (pc12, 12, true), // AFE0_AD8
+    Pc13: (pc13, 13, true), // AFE0_AD6
+    Pc14: (pc14, 14, false),
+    Pc15: (pc15, 15, true), // AFE0_AD7
+    Pc16: (pc16, 16, false),
+    Pc17: (pc17, 17, false),
+    Pc18: (pc18, 18, false),
+    Pc19: (pc19, 19, false),
+    Pc20: (pc20, 20, false),
+    Pc21: (pc21, 21, false),
+    Pc22: (pc22, 22, false),
+    Pc23: (pc23, 23, false),
+    Pc24: (pc24, 24, false),
+    Pc25: (pc25, 25, false),
+    Pc26: (pc26, 26, true), // AFE0_AD12
+    Pc27: (pc27, 27, true), // AFE0_AD13
+    Pc28: (pc28, 28, false),
+    Pc29: (pc29, 29, true), // AFE0_AD9
+    Pc30: (pc30, 30, true), // AFE0_AD10
+    Pc31: (pc31, 31, true), // AFE0_AD11
 ],
 [
     Pd0: (pd0, 0),
@@ -749,178 +776,178 @@ pins!([
 
 #[cfg(feature = "atsam4n")]
 pins!([
-    Pa0: (pa0, 0),
-    Pa1: (pa1, 1),
-    Pa2: (pa2, 2),
-    Pa3: (pa3, 3),
-    Pa4: (pa4, 4),
-    Pa5: (pa5, 5),
-    Pa6: (pa6, 6),
-    Pa7: (pa7, 7),
-    Pa8: (pa8, 8),
-    Pa9: (pa9, 9),
-    Pa10: (pa10, 10),
-    Pa11: (pa11, 11),
-    Pa12: (pa12, 12),
-    Pa13: (pa13, 13),
-    Pa14: (pa14, 14),
-    Pa15: (pa15, 15),
-    Pa16: (pa16, 16),
-    Pa17: (pa17, 17),
-    Pa18: (pa18, 18),
-    Pa19: (pa19, 19),
-    Pa20: (pa20, 20),
-    Pa21: (pa21, 21),
-    Pa22: (pa22, 22),
-    Pa23: (pa23, 23),
-    Pa24: (pa24, 24),
-    Pa25: (pa25, 25),
-    Pa26: (pa26, 26),
-    Pa27: (pa27, 27),
-    Pa28: (pa28, 28),
-    Pa29: (pa29, 29),
-    Pa30: (pa30, 30),
-    Pa31: (pa31, 31),
+    Pa0: (pa0, 0, true), // WKUP0
+    Pa1: (pa1, 1, true), // WKUP1
+    Pa2: (pa2, 2, true), // WKUP2
+    Pa3: (pa3, 3, false),
+    Pa4: (pa4, 4, true), // WKUP3
+    Pa5: (pa5, 5, true), // WKUP4
+    Pa6: (pa6, 6, false),
+    Pa7: (pa7, 7, false),
+    Pa8: (pa8, 8, true), // WKUP5
+    Pa9: (pa9, 9, true), // WKUP6
+    Pa10: (pa10, 10, false),
+    Pa11: (pa11, 11, true), // WKUP7
+    Pa12: (pa12, 12, false),
+    Pa13: (pa13, 13, false),
+    Pa14: (pa14, 14, true), // WKUP8
+    Pa15: (pa15, 15, true), // WKUP14
+    Pa16: (pa16, 16, true), // WKUP15
+    Pa17: (pa17, 17, true), // AD0
+    Pa18: (pa18, 18, true), // AD1
+    Pa19: (pa19, 19, true), // AD2/WKUP9
+    Pa20: (pa20, 20, true), // AD3/WKUP10
+    Pa21: (pa21, 21, true), // AD8
+    Pa22: (pa22, 22, true), // AD9
+    Pa23: (pa23, 23, false),
+    Pa24: (pa24, 24, false),
+    Pa25: (pa25, 25, false),
+    Pa26: (pa26, 26, false),
+    Pa27: (pa27, 27, false),
+    Pa28: (pa28, 28, false),
+    Pa29: (pa29, 29, false),
+    Pa30: (pa30, 30, true), // WKUP11
+    Pa31: (pa31, 31, false),
 ],[
-    Pb0: (pb0, 0, false),
-    Pb1: (pb1, 1, false),
-    Pb2: (pb2, 2, false),
-    Pb3: (pb3, 3, false),
-    Pb4: (pb4, 4, true), // SYSIO4 - TDI
-    Pb5: (pb5, 5, true), // SYSIO5 - TDO/TRACESWO
-    Pb6: (pb6, 6, true), // SYSIO6 - TMS/SWDIO
-    Pb7: (pb7, 7, true), // SYSIO7 - TCK/SWCLK
-    Pb8: (pb8, 8, false),
-    Pb9: (pb9, 9, false),
-    Pb10: (pb10, 10, false),
-    Pb11: (pb11, 11, false),
-    Pb12: (pb12, 12, true), // SYSIO12 - ERASE
-    Pb13: (pb13, 13, false),
-    Pb14: (pb14, 14, false),
+    Pb0: (pb0, 0, true, false), // AD4
+    Pb1: (pb1, 1, true, false), // AD5
+    Pb2: (pb2, 2, true, false), // AD6/WKUP12
+    Pb3: (pb3, 3, true, false), // AD7
+    Pb4: (pb4, 4, false, true), // | SYSIO4 - TDI
+    Pb5: (pb5, 5, true, true), // WKUP13 | SYSIO5 - TDO/TRACESWO
+    Pb6: (pb6, 6, false, true), // | SYSIO6 - TMS/SWDIO
+    Pb7: (pb7, 7, false, true), // | SYSIO7 - TCK/SWCLK
+    Pb8: (pb8, 8, false, false),
+    Pb9: (pb9, 9, false, false),
+    Pb10: (pb10, 10, false, false),
+    Pb11: (pb11, 11, false, false),
+    Pb12: (pb12, 12, false, true), // | SYSIO12 - ERASE
+    Pb13: (pb13, 13, true, false), // DAC0
+    Pb14: (pb14, 14, false, false),
 
     // PB15-31 do not exist.
 ],
 [
-    Pc0: (pc0, 0),
-    Pc1: (pc1, 1),
-    Pc2: (pc2, 2),
-    Pc3: (pc3, 3),
-    Pc4: (pc4, 4),
-    Pc5: (pc5, 5),
-    Pc6: (pc6, 6),
-    Pc7: (pc7, 7),
-    Pc8: (pc8, 8),
-    Pc9: (pc9, 9),
-    Pc10: (pc10, 10),
-    Pc11: (pc11, 11),
-    Pc12: (pc12, 12),
-    Pc13: (pc13, 13),
-    Pc14: (pc14, 14),
-    Pc15: (pc15, 15),
-    Pc16: (pc16, 16),
-    Pc17: (pc17, 17),
-    Pc18: (pc18, 18),
-    Pc19: (pc19, 19),
-    Pc20: (pc20, 20),
-    Pc21: (pc21, 21),
-    Pc22: (pc22, 22),
-    Pc23: (pc23, 23),
-    Pc24: (pc24, 24),
-    Pc25: (pc25, 25),
-    Pc26: (pc26, 26),
-    Pc27: (pc27, 27),
-    Pc28: (pc28, 28),
-    Pc29: (pc29, 29),
-    Pc30: (pc30, 30),
-    Pc31: (pc31, 31),
+    Pc0: (pc0, 0, false),
+    Pc1: (pc1, 1, false),
+    Pc2: (pc2, 2, false),
+    Pc3: (pc3, 3, false),
+    Pc4: (pc4, 4, false),
+    Pc5: (pc5, 5, false),
+    Pc6: (pc6, 6, false),
+    Pc7: (pc7, 7, false),
+    Pc8: (pc8, 8, false),
+    Pc9: (pc9, 9, false),
+    Pc10: (pc10, 10, false),
+    Pc11: (pc11, 11, false),
+    Pc12: (pc12, 12, true), // AD12
+    Pc13: (pc13, 13, true), // AD10
+    Pc14: (pc14, 14, false),
+    Pc15: (pc15, 15, true), // AD11
+    Pc16: (pc16, 16, false),
+    Pc17: (pc17, 17, false),
+    Pc18: (pc18, 18, false),
+    Pc19: (pc19, 19, false),
+    Pc20: (pc20, 20, false),
+    Pc21: (pc21, 21, false),
+    Pc22: (pc22, 22, false),
+    Pc23: (pc23, 23, false),
+    Pc24: (pc24, 24, false),
+    Pc25: (pc25, 25, false),
+    Pc26: (pc26, 26, false),
+    Pc27: (pc27, 27, false),
+    Pc28: (pc28, 28, false),
+    Pc29: (pc29, 29, true), // AD13
+    Pc30: (pc30, 30, true), // AD14
+    Pc31: (pc31, 31, true), // AD15
 ], [], []);
 
 #[cfg(feature = "atsam4s")]
 pins!([
-    Pa0: (pa0, 0),
-    Pa1: (pa1, 1),
-    Pa2: (pa2, 2),
-    Pa3: (pa3, 3),
-    Pa4: (pa4, 4),
-    Pa5: (pa5, 5),
-    Pa6: (pa6, 6),
-    Pa7: (pa7, 7),
-    Pa8: (pa8, 8),
-    Pa9: (pa9, 9),
-    Pa10: (pa10, 10),
-    Pa11: (pa11, 11),
-    Pa12: (pa12, 12),
-    Pa13: (pa13, 13),
-    Pa14: (pa14, 14),
-    Pa15: (pa15, 15),
-    Pa16: (pa16, 16),
-    Pa17: (pa17, 17),
-    Pa18: (pa18, 18),
-    Pa19: (pa19, 19),
-    Pa20: (pa20, 20),
-    Pa21: (pa21, 21),
-    Pa22: (pa22, 22),
-    Pa23: (pa23, 23),
-    Pa24: (pa24, 24),
-    Pa25: (pa25, 25),
-    Pa26: (pa26, 26),
-    Pa27: (pa27, 27),
-    Pa28: (pa28, 28),
-    Pa29: (pa29, 29),
-    Pa30: (pa30, 30),
-    Pa31: (pa31, 31),
+    Pa0: (pa0, 0, true), // WKUP0
+    Pa1: (pa1, 1, true), // WKUP1
+    Pa2: (pa2, 2, true), // WKUP2
+    Pa3: (pa3, 3, false),
+    Pa4: (pa4, 4, true), // WKUP3
+    Pa5: (pa5, 5, true), // WKUP4
+    Pa6: (pa6, 6, false),
+    Pa7: (pa7, 7, false),
+    Pa8: (pa8, 8, true), // WKUP5
+    Pa9: (pa9, 9, true), // WKUP6
+    Pa10: (pa10, 10, false),
+    Pa11: (pa11, 11, true), // WKUP7
+    Pa12: (pa12, 12, false),
+    Pa13: (pa13, 13, false),
+    Pa14: (pa14, 14, true), // WKUP8
+    Pa15: (pa15, 15, true), // WKUP14/PIODCEN1
+    Pa16: (pa16, 16, true), // WKUP15/PIODCEN2
+    Pa17: (pa17, 17, true), // AD0
+    Pa18: (pa18, 18, true), // AD1
+    Pa19: (pa19, 19, true), // AD2/WKUP9
+    Pa20: (pa20, 20, true), // AD3/WKUP10
+    Pa21: (pa21, 21, true), // AD8
+    Pa22: (pa22, 22, true), // AD9
+    Pa23: (pa23, 23, true), // PIODCCLK
+    Pa24: (pa24, 24, true), // PIODC0
+    Pa25: (pa25, 25, true), // PIODC1
+    Pa26: (pa26, 26, true), // PIODC2
+    Pa27: (pa27, 27, true), // PIODC3
+    Pa28: (pa28, 28, true), // PIODC4
+    Pa29: (pa29, 29, true), // PIODC5
+    Pa30: (pa30, 30, true), // WKUP11/PIODC6
+    Pa31: (pa31, 31, true), // PIODC7
 ],[
-    Pb0: (pb0, 0, false),
-    Pb1: (pb1, 1, false),
-    Pb2: (pb2, 2, false),
-    Pb3: (pb3, 3, false),
-    Pb4: (pb4, 4, true), // SYSIO4 - TDI
-    Pb5: (pb5, 5, true), // SYSIO5 - TDO/TRACESWO
-    Pb6: (pb6, 6, true), // SYSIO6 - TMS/SWDIO
-    Pb7: (pb7, 7, true), // SYSIO7 - TCK/SWCLK
-    Pb8: (pb8, 8, false),
-    Pb9: (pb9, 9, false),
-    Pb10: (pb10, 10, true), // SYSIO10 - DDM
-    Pb11: (pb11, 11, true), // SYSIO11 - DDP
-    Pb12: (pb12, 12, true), // SYSIO12 - ERASE
-    Pb13: (pb13, 13, false),
-    Pb14: (pb14, 14, false),
+    Pb0: (pb0, 0, true, false), // AD4/RTCOUT0
+    Pb1: (pb1, 1, true, false), // AD5/RTCOUT1
+    Pb2: (pb2, 2, true, false), // AD6/WKUP12
+    Pb3: (pb3, 3, true, false), // AD7
+    Pb4: (pb4, 4, false, true), // | SYSIO4 - TDI
+    Pb5: (pb5, 5, true, true), // WKUP13 | SYSIO5 - TDO/TRACESWO
+    Pb6: (pb6, 6, false, true), // | SYSIO6 - TMS/SWDIO
+    Pb7: (pb7, 7, false, true), // | SYSIO7 - TCK/SWCLK
+    Pb8: (pb8, 8, false, false),
+    Pb9: (pb9, 9, false, false),
+    Pb10: (pb10, 10, false, true), // | SYSIO10 - DDM
+    Pb11: (pb11, 11, false, true), // | SYSIO11 - DDP
+    Pb12: (pb12, 12, false, true), // | SYSIO12 - ERASE
+    Pb13: (pb13, 13, true, false), // DAC0
+    Pb14: (pb14, 14, true, false), // DAC1
 
     // PB15-31 do not exist.
 ],
 [
-    Pc0: (pc0, 0),
-    Pc1: (pc1, 1),
-    Pc2: (pc2, 2),
-    Pc3: (pc3, 3),
-    Pc4: (pc4, 4),
-    Pc5: (pc5, 5),
-    Pc6: (pc6, 6),
-    Pc7: (pc7, 7),
-    Pc8: (pc8, 8),
-    Pc9: (pc9, 9),
-    Pc10: (pc10, 10),
-    Pc11: (pc11, 11),
-    Pc12: (pc12, 12),
-    Pc13: (pc13, 13),
-    Pc14: (pc14, 14),
-    Pc15: (pc15, 15),
-    Pc16: (pc16, 16),
-    Pc17: (pc17, 17),
-    Pc18: (pc18, 18),
-    Pc19: (pc19, 19),
-    Pc20: (pc20, 20),
-    Pc21: (pc21, 21),
-    Pc22: (pc22, 22),
-    Pc23: (pc23, 23),
-    Pc24: (pc24, 24),
-    Pc25: (pc25, 25),
-    Pc26: (pc26, 26),
-    Pc27: (pc27, 27),
-    Pc28: (pc28, 28),
-    Pc29: (pc29, 29),
-    Pc30: (pc30, 30),
-    Pc31: (pc31, 31),
+    Pc0: (pc0, 0, false),
+    Pc1: (pc1, 1, false),
+    Pc2: (pc2, 2, false),
+    Pc3: (pc3, 3, false),
+    Pc4: (pc4, 4, false),
+    Pc5: (pc5, 5, false),
+    Pc6: (pc6, 6, false),
+    Pc7: (pc7, 7, false),
+    Pc8: (pc8, 8, false),
+    Pc9: (pc9, 9, false),
+    Pc10: (pc10, 10, false),
+    Pc11: (pc11, 11, false),
+    Pc12: (pc12, 12, true), // AD12
+    Pc13: (pc13, 13, true), // AD10
+    Pc14: (pc14, 14, false),
+    Pc15: (pc15, 15, true), // AD11
+    Pc16: (pc16, 16, false),
+    Pc17: (pc17, 17, false),
+    Pc18: (pc18, 18, false),
+    Pc19: (pc19, 19, false),
+    Pc20: (pc20, 20, false),
+    Pc21: (pc21, 21, false),
+    Pc22: (pc22, 22, false),
+    Pc23: (pc23, 23, false),
+    Pc24: (pc24, 24, false),
+    Pc25: (pc25, 25, false),
+    Pc26: (pc26, 26, false),
+    Pc27: (pc27, 27, false),
+    Pc28: (pc28, 28, false),
+    Pc29: (pc29, 29, true), // AD13
+    Pc30: (pc30, 30, true), // AD14
+    Pc31: (pc31, 31, false),
 ], [], []);
 
 #[macro_export]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,10 +81,15 @@ use core::mem;
 
 pub use embedded_time as time;
 
+// NOTE: In ASF atsam4s uses sam/drivers/adc/adc.c whereas atsam4n uses sam/drivers/adc/adc2.c
+#[cfg(feature = "atsam4s")]
+pub mod adc;
 pub mod chipid;
 pub mod clock;
 pub mod delay;
 pub mod gpio;
+#[cfg(feature = "atsam4s")]
+pub mod pdc;
 pub mod prelude;
 pub mod rtt;
 pub mod serial;

--- a/src/pdc.rs
+++ b/src/pdc.rs
@@ -1,0 +1,312 @@
+//! PDC Traits for use with PDC-enabled peripherals
+//!
+//! Common interface to use with PDC enabled peripherals
+//!
+//! TODO: Currently only implements Rx mode (e.g. Adc)
+
+use core::marker::PhantomData;
+use core::sync::atomic::{self, compiler_fence, Ordering};
+use core::{mem, ptr};
+use embedded_dma::{StaticReadBuffer, StaticWriteBuffer};
+
+/// Read transfer
+pub struct R;
+
+/// Write transfer
+pub struct W;
+
+/// DMA Receiver
+pub struct RxDma<PAYLOAD> {
+    pub(crate) payload: PAYLOAD,
+}
+
+pub trait Receive {
+    type TransmittedWord;
+}
+
+pub trait Transmit {
+    type ReceivedWord;
+}
+
+/// Trait for DMA readings from peripheral to memory.
+pub trait ReadDma<B, RS>: Receive
+where
+    B: StaticWriteBuffer<Word = RS>,
+    Self: core::marker::Sized + TransferPayload,
+{
+    fn read(self, buffer: B) -> Transfer<W, B, Self>;
+}
+
+/// Trait for DMA writing from memory to peripheral.
+pub trait WriteDma<B, TS>: Transmit
+where
+    B: StaticReadBuffer<Word = TS>,
+    Self: core::marker::Sized + TransferPayload,
+{
+    fn write(self, buffer: B) -> Transfer<R, B, Self>;
+}
+
+/// Trait for DMA simultaneously reading and writing within one synchronous operation. Panics if both buffers are not of equal length.
+pub trait ReadWriteDma<RXB, TXB, TS>: Transmit
+where
+    RXB: StaticWriteBuffer<Word = TS>,
+    TXB: StaticReadBuffer<Word = TS>,
+    Self: core::marker::Sized + TransferPayload,
+{
+    fn read_write(self, rx_buffer: RXB, tx_buffer: TXB) -> Transfer<W, (RXB, TXB), Self>;
+}
+
+pub trait TransferPayload {
+    fn start(&mut self);
+    fn stop(&mut self);
+    fn in_progress(&self) -> bool;
+}
+
+pub struct Transfer<MODE, BUFFER, PAYLOAD>
+where
+    PAYLOAD: TransferPayload,
+{
+    _mode: PhantomData<MODE>,
+    buffer: BUFFER,
+    payload: PAYLOAD,
+}
+
+/* TODO Needed for pdc_tx
+impl<BUFFER, PAYLOAD> Transfer<R, BUFFER, PAYLOAD>
+where
+    PAYLOAD: TransferPayload,
+{
+    pub(crate) fn r(buffer: BUFFER, payload: PAYLOAD) -> Self {
+        Transfer {
+            _mode: PhantomData,
+            buffer,
+            payload,
+        }
+    }
+}
+*/
+
+impl<BUFFER, PAYLOAD> Transfer<W, BUFFER, PAYLOAD>
+where
+    PAYLOAD: TransferPayload,
+{
+    pub(crate) fn w(buffer: BUFFER, payload: PAYLOAD) -> Self {
+        Transfer {
+            _mode: PhantomData,
+            buffer,
+            payload,
+        }
+    }
+}
+
+impl<MODE, BUFFER, PAYLOAD> Drop for Transfer<MODE, BUFFER, PAYLOAD>
+where
+    PAYLOAD: TransferPayload,
+{
+    fn drop(&mut self) {
+        self.payload.stop();
+        compiler_fence(Ordering::SeqCst);
+    }
+}
+
+impl<BUFFER, PAYLOAD, MODE> Transfer<MODE, BUFFER, RxDma<PAYLOAD>>
+where
+    RxDma<PAYLOAD>: TransferPayload,
+{
+    pub fn is_done(&self) -> bool {
+        !self.payload.in_progress()
+    }
+
+    pub fn wait(mut self) -> (BUFFER, RxDma<PAYLOAD>) {
+        while !self.is_done() {}
+
+        atomic::compiler_fence(Ordering::Acquire);
+
+        self.payload.stop();
+
+        // we need a read here to make the Acquire fence effective
+        // we do *not* need this if `dma.stop` does a RMW operation
+        unsafe {
+            ptr::read_volatile(&0);
+        }
+
+        // we need a fence here for the same reason we need one in `Transfer.wait`
+        atomic::compiler_fence(Ordering::Acquire);
+
+        // `Transfer` needs to have a `Drop` implementation, because we accept
+        // managed buffers that can free their memory on drop. Because of that
+        // we can't move out of the `Transfer`'s fields, so we use `ptr::read`
+        // and `mem::forget`.
+        //
+        // NOTE(unsafe) There is no panic branch between getting the resources
+        // and forgetting `self`.
+        unsafe {
+            let buffer = ptr::read(&self.buffer);
+            let payload = ptr::read(&self.payload);
+            mem::forget(self);
+            (buffer, payload)
+        }
+    }
+}
+
+macro_rules! pdc_rx {
+    (
+        $Periph:ident: $periph:ident
+    ) => {
+        impl $Periph {
+            /// Sets the PDC receive address pointer
+            pub fn set_receive_address(&mut self, address: u32) {
+                self.$periph
+                    .rpr
+                    .write(|w| unsafe { w.rxptr().bits(address) });
+            }
+
+            /// Sets the receive increment counter
+            /// Will increment by the count * size of the peripheral data
+            pub fn set_receive_counter(&mut self, count: u16) {
+                self.$periph.rcr.write(|w| unsafe { w.rxctr().bits(count) });
+            }
+
+            /// Sets the PDC receive next address pointer
+            pub fn set_receive_next_address(&mut self, address: u32) {
+                self.$periph
+                    .rnpr
+                    .write(|w| unsafe { w.rxnptr().bits(address) });
+            }
+
+            /// Sets the receive next increment counter
+            /// Will increment by the count * size of the peripheral data
+            pub fn set_receive_next_counter(&mut self, count: u16) {
+                self.$periph
+                    .rncr
+                    .write(|w| unsafe { w.rxnctr().bits(count) });
+            }
+
+            /// Starts the PDC transfer
+            pub fn start_rx_pdc(&mut self) {
+                self.$periph.ptcr.write_with_zero(|w| w.rxten().set_bit());
+            }
+
+            /// Stops the PDC transfer
+            pub fn stop_rx_pdc(&mut self) {
+                self.$periph.ptcr.write_with_zero(|w| w.rxtdis().set_bit());
+            }
+
+            /// Returns `true` if the PDC is active and may be receiving data
+            pub fn active_rx_pdc(&self) -> bool {
+                self.$periph.ptsr.read().rxten().bit()
+            }
+
+            /// Returns `true` if DMA is still in progress
+            /// Uses rxbuff, which checks both receive and receive next counters to see if they are 0
+            pub fn rx_in_progress(&self) -> bool {
+                !self.$periph.isr.read().rxbuff().bit()
+            }
+
+            /// Enable ENDRX (End of Receive) interrupt
+            /// Triggered when RCR reaches 0
+            pub fn enable_endrx_interrupt(&mut self) {
+                self.$periph.ier.write_with_zero(|w| w.endrx().set_bit());
+            }
+
+            /// Disable ENDRX (End of Receive) interrupt
+            pub fn disable_endrx_interrupt(&mut self) {
+                self.$periph.idr.write_with_zero(|w| w.endrx().set_bit());
+            }
+
+            /// Enable RXBUFF (Receive Buffer Full) interrupt
+            /// Triggered when RCR and RNCR reach 0
+            pub fn enable_rxbuff_interrupt(&mut self) {
+                self.$periph.ier.write_with_zero(|w| w.rxbuff().set_bit());
+            }
+
+            /// Disable RXBUFF (Receive Buffer Full) interrupt
+            pub fn disable_rxbuff_interrupt(&mut self) {
+                self.$periph.idr.write_with_zero(|w| w.rxbuff().set_bit());
+            }
+        }
+    };
+}
+pub(crate) use pdc_rx;
+
+/* TODO Commenting out until first usage (likely SPI)
+macro_rules! pdc_tx {
+    (
+        $Periph:ident: $periph:ident
+    ) => {
+        impl $Periph {
+            /// Sets the PDC transmit address pointer
+            pub fn set_transmit_address(&mut self, address: u32) {
+                self.$periph
+                    .rpr
+                    .write(|w| unsafe { w.txptr().bits(address) });
+            }
+
+            /// Sets the transmit increment counter
+            /// Will increment by the count * size of the peripheral data
+            pub fn set_transmit_counter(&mut self, count: u16) {
+                self.$periph.rcr.write(|w| unsafe { w.txctr().bits(count) });
+            }
+
+            /// Sets the PDC transmit next address pointer
+            pub fn set_transmit_next_address(&mut self, address: u32) {
+                self.$periph
+                    .rnpr
+                    .write(|w| unsafe { w.txnptr().bits(address) });
+            }
+
+            /// Sets the transmit next increment counter
+            /// Will increment by the count * size of the peripheral data
+            pub fn set_transmit_next_counter(&mut self, count: u16) {
+                self.$periph
+                    .rncr
+                    .write(|w| unsafe { w.txnctr().bits(count) });
+            }
+
+            /// Starts the PDC transfer
+            pub fn start_tx_pdc(&mut self) {
+                self.$periph.ptcr.write_with_zero(|w| w.txten().set_bit());
+            }
+
+            /// Stops the PDC transfer
+            pub fn stop_tx_pdc(&mut self) {
+                self.$periph.ptcr.write_with_zero(|w| w.txtdis().set_bit());
+            }
+
+            /// Returns `true` if the PDC is active and may be receiving data
+            pub fn active_tx_pdc(&self) -> bool {
+                self.$periph.ptsr.read().txten().bit()
+            }
+
+            /// Returns `true` if DMA is still in progress
+            /// Uses rxbuff, which checks both transmit and transmit next counters to see if they are 0
+            pub fn tx_in_progress(&self) -> bool {
+                !self.$periph.isr.read().txbufe().bit()
+            }
+
+            /// Enable ENDRX (End of Transmit) interrupt
+            /// Triggered when RCR reaches 0
+            pub fn enable_endrx_interrupt(&mut self) {
+                self.$periph.ier.write_with_zero(|w| w.endtx().set_bit());
+            }
+
+            /// Disable ENDRX (End of Transmit) interrupt
+            pub fn disable_endrx_interrupt(&mut self) {
+                self.$periph.idr.write_with_zero(|w| w.endtx().set_bit());
+            }
+
+            /// Enable RXBUFF (Transmit Buffer Full) interrupt
+            /// Triggered when RCR and RNCR reach 0
+            pub fn enable_rxbuff_interrupt(&mut self) {
+                self.$periph.ier.write_with_zero(|w| w.txbufe().set_bit());
+            }
+
+            /// Disable RXBUFF (Transmit Buffer Full) interrupt
+            pub fn disable_rxbuff_interrupt(&mut self) {
+                self.$periph.idr.write_with_zero(|w| w.txbufe().set_bit());
+            }
+        }
+    };
+}
+pub(crate) use pdc_tx;
+*/


### PR DESCRIPTION
Adds ADC support for ATSAM4S

- atsam4e has different ADC hardware
- atsam4n has similar ADC hardware, but ASF implements it separately so it probably warrants a closer look (adc2.c vs. adc.c)
- Adds basic Rx PDC support (and much of the initial work for Tx and Rx+Tx PDC support)
- Adds ExtFn GPIO pins to give ownership of GPIO pins that are configured by the hardware rather than a system mux or GPIO hardware
- Adds basic ADC support for the atsam4s channel 15 temperature sensor