### PR TITLE
Fixing UDP atsam4s PLLB clock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ defmt = "0.2"
 embedded-dma = "0.1.2"
 embedded-hal = { version = "0.2.4", features = ["unproven"] }
 embedded-time = "0.10.1"
-log = "0.4"
 nb = "0.1.0"
 paste = "1.0"
 usb-device = { git = "https://github.com/haata/usb-device.git", optional = true }

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -179,13 +179,11 @@ fn setup_main_clock(pmc: &PMC, main_clock: MainClock) -> Hertz {
 
             #[cfg(feature = "usb")]
             {
-                // Setup PLLB for 96 MHz operation (12 MHz * (16 / 2) = 96 MHz)
+                // Setup PLLB for 96 MHz operation (12 MHz * (8 / 1) = 96 MHz)
                 // 96 MHz will be /2 to get 48 MHz
-                let multiplier: u16 = 16;
-                let divider: u8 = 2;
+                let multiplier: u16 = 8;
+                let divider: u8 = 1;
                 enable_pllb_clock(pmc, multiplier, divider);
-
-                unsafe { PLLB_MULTIPLIER = multiplier }; // Save for reenable_pllb_clock
             }
 
             // 0 = no prescaling
@@ -507,6 +505,8 @@ fn enable_pllb_clock(pmc: &PMC, multiplier: u16, divider: u8) {
             .divb()
             .bits(divider)
     });
+
+    unsafe { PLLB_MULTIPLIER = multiplier - 1 }; // Save for reenable_pllb_clock
 }
 
 /// Used to re-enable pllb clock if disabled later at runtime

--- a/src/udp/bus.rs
+++ b/src/udp/bus.rs
@@ -1,7 +1,7 @@
 use crate::clock::{Disabled, UdpClock};
 use crate::gpio::{Pb10, Pb11, SysFn};
 use crate::pac::{PMC, UDP};
-use crate::udp::Endpoint;
+use crate::udp::{frm_num, Endpoint, UdpEndpointAddress, UdpEndpointType, UdpUsbDirection};
 use crate::BorrowUnchecked;
 use core::cell::RefCell;
 use core::marker::PhantomData;
@@ -29,24 +29,104 @@ pub struct UdpBus {
 impl UdpBus {
     /// Initialize UDP as a USB device
     pub fn new(udp: UDP, _clock: UdpClock<Disabled>, _ddm: Pb10<SysFn>, _ddp: Pb11<SysFn>) -> Self {
-        log::trace!("UdpBus::new()");
+        let endpoints = [
+            Mutex::new(RefCell::new(Endpoint::new(0))),
+            Mutex::new(RefCell::new(Endpoint::new(1))),
+            Mutex::new(RefCell::new(Endpoint::new(2))),
+            Mutex::new(RefCell::new(Endpoint::new(3))),
+            Mutex::new(RefCell::new(Endpoint::new(4))),
+            Mutex::new(RefCell::new(Endpoint::new(5))),
+            Mutex::new(RefCell::new(Endpoint::new(6))),
+            Mutex::new(RefCell::new(Endpoint::new(7))),
+        ];
+        let udp = Mutex::new(RefCell::new(udp));
+        let sof_errors = Mutex::new(RefCell::new(0));
         Self {
-            udp: Mutex::new(RefCell::new(udp)),
-            endpoints: [
-                Mutex::new(RefCell::new(Endpoint::new(0))),
-                Mutex::new(RefCell::new(Endpoint::new(1))),
-                Mutex::new(RefCell::new(Endpoint::new(2))),
-                Mutex::new(RefCell::new(Endpoint::new(3))),
-                Mutex::new(RefCell::new(Endpoint::new(4))),
-                Mutex::new(RefCell::new(Endpoint::new(5))),
-                Mutex::new(RefCell::new(Endpoint::new(6))),
-                Mutex::new(RefCell::new(Endpoint::new(7))),
-            ],
+            udp,
+            endpoints,
             clock: PhantomData,
             ddm: PhantomData,
             ddp: PhantomData,
-            sof_errors: Mutex::new(RefCell::new(0)),
+            sof_errors,
         }
+    }
+
+    /// Enables UDP MCK (from MCK)
+    fn enable_periph_clk(&self) {
+        #[cfg(feature = "atsam4e")]
+        PMC::borrow_unchecked(|pmc| pmc.pmc_pcer1.write_with_zero(|w| w.pid35().set_bit()));
+        #[cfg(feature = "atsam4s")]
+        PMC::borrow_unchecked(|pmc| pmc.pmc_pcer1.write_with_zero(|w| w.pid34().set_bit()));
+    }
+
+    /// Disables UDP MCK (from MCK)
+    /// Used when entering USB suspend state
+    fn disable_periph_clk(&self) {
+        #[cfg(feature = "atsam4e")]
+        PMC::borrow_unchecked(|pmc| pmc.pmc_pcdr1.write_with_zero(|w| w.pid35().set_bit()));
+        #[cfg(feature = "atsam4s")]
+        PMC::borrow_unchecked(|pmc| pmc.pmc_pcdr1.write_with_zero(|w| w.pid34().set_bit()));
+    }
+
+    /// Disables each of the endpoints
+    /// Also flushes resets/flushes the fifo
+    fn disable(&self) {
+        // Enable UDP MCK (from MCK)
+        self.enable_periph_clk();
+
+        cortex_m::interrupt::free(|cs| {
+            // Disable endpoints
+            for i in 0..NUM_ENDPOINTS {
+                self.endpoints[i].borrow(cs).borrow_mut().disable();
+            }
+
+            // Disable Transceiver (TXDIS)
+            // Disable 1.5k pullup
+            self.udp
+                .borrow(cs)
+                .borrow()
+                .txvc
+                .modify(|_, w| w.txvdis().set_bit().puon().clear_bit());
+        });
+    }
+
+    /// Enable each of the configured endpoints
+    /// Only allocated endpoints are enabled
+    fn _enable(&self) {
+        defmt::trace!("UdpBus::enable()");
+
+        // Start with integrated 1.5k pull-up on D+ disabled
+        cortex_m::interrupt::free(|cs| {
+            self.udp
+                .borrow(cs)
+                .borrow()
+                .txvc
+                .modify(|_, w| w.puon().clear_bit());
+        });
+
+        // Enable UDP MCK (from MCK)
+        self.enable_periph_clk();
+
+        // Enable fast restart signal
+        PMC::borrow_unchecked(|pmc| pmc.pmc_fsmr.modify(|_, w| w.usbal().set_bit()));
+
+        // Enable UDP Clock (UDPCK)
+        PMC::borrow_unchecked(|pmc| pmc.pmc_scer.write_with_zero(|w| w.udp().set_bit()));
+
+        // Enable integrated 1.5k pull-up on D+
+        cortex_m::interrupt::free(|cs| {
+            self.udp
+                .borrow(cs)
+                .borrow()
+                .txvc
+                .modify(|_, w| w.puon().set_bit());
+
+            // Enable allocated endpoints
+            for i in 0..NUM_ENDPOINTS {
+                self.endpoints[i].borrow(cs).borrow_mut().clear_fifo();
+                self.endpoints[i].borrow(cs).borrow_mut().enable();
+            }
+        });
     }
 }
 
@@ -59,28 +139,26 @@ impl UsbBus for UdpBus {
         max_packet_size: u16,
         interval: u8,
     ) -> usb_device::Result<EndpointAddress> {
-        log::trace!(
-            "UsbBus::alloc_ep({:?}, {:?}, {:?}, {}, {})",
-            ep_dir,
-            ep_addr,
-            ep_type,
+        defmt::trace!(
+            "UdpBus::alloc_ep({:?}, {:?}, {:?}, {}, {})",
+            UdpUsbDirection { inner: ep_dir },
+            UdpEndpointAddress { inner: ep_addr },
+            UdpEndpointType { inner: ep_type },
             max_packet_size,
             interval
         );
-        match ep_addr {
-            Some(ep_addr) => cortex_m::interrupt::free(|cs| {
-                self.endpoints[ep_addr.index()]
+        cortex_m::interrupt::free(|cs| {
+            match ep_addr {
+                Some(ep_addr) => self.endpoints[ep_addr.index()]
                     .borrow(cs)
                     .borrow_mut()
-                    .alloc(ep_type, ep_dir, max_packet_size, interval)
-            }),
-            None => {
-                // Iterate over all of the endpoints and try to allocate one
-                // Keep trying even if the first selection fails as there are different
-                // endpoint specs for each one.
-                // Only Control OUT endpoints are allocated, Control Endpoints are shared between
-                // IN and OUT (allocated a Control IN endpoint is a no-op).
-                cortex_m::interrupt::free(|cs| {
+                    .alloc(ep_type, ep_dir, max_packet_size, interval),
+                None => {
+                    // Iterate over all of the endpoints and try to allocate one
+                    // Keep trying even if the first selection fails as there are different
+                    // endpoint specs for each one.
+                    // Only Control OUT endpoints are allocated, Control Endpoints are shared between
+                    // IN and OUT (allocated a Control IN endpoint is a no-op).
                     for i in 0..NUM_ENDPOINTS {
                         match self.endpoints[i].borrow(cs).borrow_mut().alloc(
                             ep_type,
@@ -100,36 +178,15 @@ impl UsbBus for UdpBus {
 
                     // Couldn't find a free endpoint as specified
                     Err(usb_device::UsbError::InvalidEndpoint)
-                })
+                }
             }
-        }
+        })
     }
 
     /// Enable each of the configured endpoints
     /// Only allocated endpoints are enabled
     fn enable(&mut self) {
-        log::trace!("UsbBus::enable()");
-
-        // Enable UDP MCK (from MCK)
-        #[cfg(feature = "atsam4e")]
-        PMC::borrow_unchecked(|pmc| pmc.pmc_pcer1.write_with_zero(|w| w.pid35().set_bit()));
-        #[cfg(feature = "atsam4s")]
-        PMC::borrow_unchecked(|pmc| pmc.pmc_pcer1.write_with_zero(|w| w.pid34().set_bit()));
-
-        // Enable fast restart signal
-        PMC::borrow_unchecked(|pmc| pmc.pmc_fsmr.modify(|_, w| w.usbal().set_bit()));
-
-        // Enable UDP Clock (UDPCK)
-        PMC::borrow_unchecked(|pmc| pmc.pmc_scer.write_with_zero(|w| w.udp().set_bit()));
-
-        // Enable integrated 1.5k pull-up on D+
-        cortex_m::interrupt::free(|cs| {
-            self.udp
-                .borrow(cs)
-                .borrow()
-                .txvc
-                .modify(|_, w| w.puon().set_bit());
-        });
+        self._enable();
     }
 
     /// Resets state of all endpoints and peripheral flags so that they can be enumerated
@@ -139,27 +196,16 @@ impl UsbBus for UdpBus {
         let imr_reg = UDP::borrow_unchecked(|udp| udp.imr.as_ptr());
         let faddr_reg = UDP::borrow_unchecked(|udp| udp.faddr.as_ptr());
         let glb_stat_reg = UDP::borrow_unchecked(|udp| udp.glb_stat.as_ptr());
-        log::trace!(
-            "UsbBus::reset() txvc:{:#x} imr:{:#x} faddr:{:#x} glb_stat:{:#x}",
+        defmt::trace!(
+            "{} UdpBus::reset() txvc:{:#x} imr:{:#x} faddr:{:#x} glb_stat:{:#x}",
+            frm_num(),
             unsafe { core::ptr::read(txvc_reg) },
             unsafe { core::ptr::read(imr_reg) },
             unsafe { core::ptr::read(faddr_reg) },
             unsafe { core::ptr::read(glb_stat_reg) }
         );
 
-        // Reset endpoint0
         cortex_m::interrupt::free(|cs| {
-            self.endpoints[0].borrow(cs).borrow_mut().reset();
-        });
-
-        // Enable general UDP interrupts
-        cortex_m::interrupt::free(|cs| {
-            self.udp
-                .borrow(cs)
-                .borrow()
-                .ier
-                .write_with_zero(|w| w.rxsusp().set_bit().sofint().set_bit());
-
             // Enable transceiver
             self.udp
                 .borrow(cs)
@@ -184,14 +230,29 @@ impl UsbBus for UdpBus {
                 .borrow()
                 .faddr
                 .modify(|_, w| unsafe { w.fen().set_bit().fadd().bits(0) });
+
+            // Enable general UDP interrupts
+            self.udp
+                .borrow(cs)
+                .borrow()
+                .ier
+                .write_with_zero(|w| w.rxsusp().set_bit().sofint().set_bit());
         });
+
+        // Reset endpoints
+        for i in 0..NUM_ENDPOINTS {
+            cortex_m::interrupt::free(|cs| {
+                self.endpoints[i].borrow(cs).borrow_mut().reset();
+            });
+        }
 
         let txvc_reg = UDP::borrow_unchecked(|udp| udp.txvc.as_ptr());
         let imr_reg = UDP::borrow_unchecked(|udp| udp.imr.as_ptr());
         let faddr_reg = UDP::borrow_unchecked(|udp| udp.faddr.as_ptr());
         let glb_stat_reg = UDP::borrow_unchecked(|udp| udp.glb_stat.as_ptr());
-        log::trace!(
-            "UsbBus::reset() (Updated) txvc:{:#x} imr:{:#x} faddr:{:#x} glb_stat:{:#x}",
+        defmt::trace!(
+            "{} UdpBus::reset() (Updated) txvc:{:#x} imr:{:#x} faddr:{:#x} glb_stat:{:#x}",
+            frm_num(),
             unsafe { core::ptr::read(txvc_reg) },
             unsafe { core::ptr::read(imr_reg) },
             unsafe { core::ptr::read(faddr_reg) },
@@ -201,7 +262,7 @@ impl UsbBus for UdpBus {
 
     /// Sets the device address, FEN (Function Enabled) and FADDEN (Function Address Enable)
     fn set_device_address(&self, addr: u8) {
-        log::trace!("UsbBus::set_device_address({})", addr);
+        defmt::info!("{} UdpBus::set_device_address({})", frm_num(), addr);
         cortex_m::interrupt::free(|cs| {
             // Set Device Address and FEN
             self.udp
@@ -220,7 +281,14 @@ impl UsbBus for UdpBus {
     }
 
     fn write(&self, ep_addr: EndpointAddress, buf: &[u8]) -> usb_device::Result<usize> {
-        log::trace!("UsbBus::write({:?}, {:?})", ep_addr, buf);
+        defmt::trace!(
+            "{} UdpBus::write({:?}, {:02X})",
+            frm_num(),
+            UdpEndpointAddress {
+                inner: Some(ep_addr)
+            },
+            buf
+        );
         cortex_m::interrupt::free(|cs| {
             // Make sure the endpoint is configured correctly
             if self.endpoints[ep_addr.index()]
@@ -241,7 +309,13 @@ impl UsbBus for UdpBus {
     }
 
     fn read(&self, ep_addr: EndpointAddress, buf: &mut [u8]) -> usb_device::Result<usize> {
-        log::trace!("UsbBus::read({:?})", ep_addr);
+        defmt::trace!(
+            "{} UdpBus::read({:02X})",
+            frm_num(),
+            UdpEndpointAddress {
+                inner: Some(ep_addr)
+            },
+        );
         cortex_m::interrupt::free(|cs| {
             // Make sure the endpoint is configured correctly
             if self.endpoints[ep_addr.index()]
@@ -262,21 +336,22 @@ impl UsbBus for UdpBus {
     }
 
     fn set_stalled(&self, ep_addr: EndpointAddress, stalled: bool) {
-        log::trace!("UsbBus::set_stalled({:?}, {})", ep_addr, stalled);
         cortex_m::interrupt::free(|cs| {
             if stalled {
-                self.endpoints[ep_addr.index()].borrow(cs).borrow().stall();
+                self.endpoints[ep_addr.index()]
+                    .borrow(cs)
+                    .borrow_mut()
+                    .stall();
             } else {
                 self.endpoints[ep_addr.index()]
                     .borrow(cs)
-                    .borrow()
+                    .borrow_mut()
                     .unstall();
             }
         });
     }
 
     fn is_stalled(&self, ep_addr: EndpointAddress) -> bool {
-        log::trace!("UsbBus::is_stalled({:?})", ep_addr);
         cortex_m::interrupt::free(|cs| {
             self.endpoints[ep_addr.index()]
                 .borrow(cs)
@@ -286,7 +361,7 @@ impl UsbBus for UdpBus {
     }
 
     fn suspend(&self) {
-        log::trace!("UsbBus::suspend()");
+        defmt::trace!("{} UdpBus::suspend()", frm_num());
         // Disable Transceiver
         cortex_m::interrupt::free(|cs| {
             self.udp
@@ -311,7 +386,7 @@ impl UsbBus for UdpBus {
     }
 
     fn resume(&self) {
-        log::trace!("UsbBus::resume()");
+        defmt::trace!("{} UdpBus::resume()", frm_num());
         // Enable PLLB (atsam4s only)
         #[cfg(feature = "atsam4s")]
         PMC::borrow_unchecked(|pmc| {
@@ -339,6 +414,9 @@ impl UsbBus for UdpBus {
     }
 
     fn poll(&self) -> PollResult {
+        // UDP MCK must be enabled before reading/writing any UDP registers
+        self.enable_periph_clk();
+
         // Read interrupt enabled status
         let imr = cortex_m::interrupt::free(|cs| self.udp.borrow(cs).borrow().imr.read());
         // Read interrupt status
@@ -359,6 +437,7 @@ impl UsbBus for UdpBus {
                     *self.sof_errors.borrow(cs).borrow_mut() += 1;
                 }
             });
+            return PollResult::None;
         }
 
         // Process endpoints - Return as soon as a pending operation is found
@@ -380,6 +459,11 @@ impl UsbBus for UdpBus {
                 ep_out_result |= ep_out;
                 ep_in_complete_result |= ep_in_complete;
                 ep_setup_result |= ep_setup;
+
+                // Exit early if this is EP0
+                if i == 0 {
+                    break;
+                }
             }
         }
 
@@ -430,7 +514,7 @@ impl UsbBus for UdpBus {
                     .write_with_zero(|w| w.rxsusp().set_bit().sofint().set_bit());
             });
 
-            log::trace!("UsbBus::poll() -> Resume");
+            defmt::info!("{} UdpBus::poll() -> Resume", frm_num());
             return PollResult::Resume;
         }
 
@@ -459,7 +543,10 @@ impl UsbBus for UdpBus {
                     .write_with_zero(|w| w.wakeup().set_bit().rxrsm().set_bit().extrsm().set_bit());
             });
 
-            log::trace!("UsbBus::poll() -> Suspend");
+            // Disable UDP MCK (after this, cannot read from UDP registers)
+            self.disable_periph_clk();
+
+            defmt::info!("{} UdpBus::poll() -> Suspend", frm_num());
             return PollResult::Suspend;
         }
 
@@ -474,7 +561,7 @@ impl UsbBus for UdpBus {
                     .write_with_zero(|w| w.endbusres().set_bit());
             });
 
-            log::trace!("UsbBus::poll() -> Reset");
+            defmt::warn!("{} UdpBus::poll() -> Reset", frm_num());
             return PollResult::Reset;
         }
 
@@ -483,6 +570,9 @@ impl UsbBus for UdpBus {
 
     /// Initiates the remote wakeup sequenec
     fn remote_wakeup(&self) -> usb_device::Result<()> {
+        // Enable UDP MCK (from MCK)
+        self.enable_periph_clk();
+
         cortex_m::interrupt::free(|cs| {
             // Check if bus has been suspended
             // NOTE: You must wait 5 ms between host suspending the bus and initiating a remote wakeup
@@ -503,24 +593,15 @@ impl UsbBus for UdpBus {
 
     /// Simulates disconnection from the USB bus
     fn force_reset(&self) -> usb_device::Result<()> {
-        log::trace!("UsbBus::force_reset()");
-        cortex_m::interrupt::free(|cs| {
-            // Disable Transceiver (TXDIS)
-            // Disable 1.5k pullup
-            self.udp
-                .borrow(cs)
-                .borrow()
-                .txvc
-                .modify(|_, w| w.txvdis().set_bit().puon().clear_bit());
+        defmt::trace!("{} UdpBus::force_reset()", frm_num());
+        self.reset();
+        self.disable();
 
-            // Re-enable
-            self.udp
-                .borrow(cs)
-                .borrow()
-                .txvc
-                .modify(|_, w| w.txvdis().clear_bit().puon().set_bit());
-        });
+        // Need to wait for the USB device to disconnect
+        let freq = crate::clock::get_master_clock_frequency();
+        cortex_m::asm::delay(freq.0 / 1000); // 1 ms
 
+        self._enable();
         Ok(())
     }
 }

--- a/src/udp/mod.rs
+++ b/src/udp/mod.rs
@@ -12,3 +12,61 @@ pub use self::bus::UdpBus;
 
 mod endpoint;
 pub use self::endpoint::Endpoint;
+
+use crate::pac::UDP;
+use crate::BorrowUnchecked;
+
+use usb_device::{
+    endpoint::{EndpointAddress, EndpointType},
+    UsbDirection,
+};
+
+/// Wrapper for defmt
+struct UdpEndpointAddress {
+    inner: Option<EndpointAddress>,
+}
+
+impl defmt::Format for UdpEndpointAddress {
+    fn format(&self, fmt: defmt::Formatter) {
+        if let Some(ep_addr) = self.inner {
+            defmt::write!(fmt, "EndpointAddress({=u8})", ep_addr.into());
+        } else {
+            defmt::write!(fmt, "EndpointAddress(None)");
+        }
+    }
+}
+
+/// Wrapper for defmt
+struct UdpEndpointType {
+    inner: EndpointType,
+}
+
+impl defmt::Format for UdpEndpointType {
+    fn format(&self, fmt: defmt::Formatter) {
+        match self.inner {
+            EndpointType::Control => defmt::write!(fmt, "EndpointType::Control"),
+            EndpointType::Isochronous => defmt::write!(fmt, "EndpointType::Isochronous"),
+            EndpointType::Bulk => defmt::write!(fmt, "EndpointType::Bulk"),
+            EndpointType::Interrupt => defmt::write!(fmt, "EndpointType::Interrupt"),
+        }
+    }
+}
+
+/// Wrapper for defmt
+struct UdpUsbDirection {
+    inner: UsbDirection,
+}
+
+impl defmt::Format for UdpUsbDirection {
+    fn format(&self, fmt: defmt::Formatter) {
+        match self.inner {
+            UsbDirection::In => defmt::write!(fmt, "UsbDirection::In"),
+            UsbDirection::Out => defmt::write!(fmt, "UsbDirection::Out"),
+        }
+    }
+}
+
+/// Retrieve current frame number (updated on SOF_EOP)
+pub fn frm_num() -> u16 {
+    UDP::borrow_unchecked(|udp| udp.frm_num.read().frm_num().bits())
+}


### PR DESCRIPTION
- Wrong clock multiplier (typo when putting UDP into powersaving mode)
  caused a lot of issues (lots of random CRC errors).
  Very surprised things worked at all with the wrong USB clock.
  (51 MHz instead of 48 MHz)
- Switch from log to defmt
- Lots of cleanup and reorganization after trying to debug the CRC
  errors from every angle
- Optimize UDP interrupt for Endpoint0 (control endpoint) so that it
  processes more quickly (ignore other endpoints until the next
  interrupt)
- Added stalled field as the atsam registers do not keep track of
  whether a STALL was sent, just that you are sending one
- Keep track of whether or not the next packet is a ZLP (zero length
  packet) in order to properly call txcomp
- Added csr_wait to handle the odd set/clear mechanism for the CSR
  register (some bits must be set 1 to do nothing, others should be set
  to 0)
- Added csr_clear for initialization
- Reset all endpoints when reset interrupt is received