### PR TITLE
Replace embedded-time with Fugit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atsam4-hal"
-version = "0.1.15"
+version = "0.2.0"
 authors = ["John W. Terrell <john@coolpeoplenetworks.com>", "Jacob Alexander <haata@kiibohd.com>"]
 edition = "2021"
 description = "HAL for the ATSAM4 microcontrollers"
@@ -16,8 +16,7 @@ defmt = "0.3"
 embedded-dma = "0.2.0"
 embedded-hal = { version = "0.2.7", features = ["unproven"] }
 embedded-storage = "0.3.0"
-embedded-time = "0.12.1"
-fugit = "0.3.5"
+fugit = { version = "0.3.6", features = ["defmt"] }
 fugit-timer = "0.1.3"
 nb = "1.0.0"
 paste = "1.0"

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -24,7 +24,7 @@ use core::marker::PhantomData;
 use core::sync::atomic::{compiler_fence, Ordering};
 use cortex_m::singleton;
 use embedded_dma::WriteBuffer;
-use embedded_time::rate::Hertz;
+use fugit::RateExtU32;
 
 #[derive(PartialEq, Eq, Copy, Clone, Debug, defmt::Format)]
 pub enum Powersaving {
@@ -206,7 +206,7 @@ impl Adc {
         }
 
         // Setup prescalar and startup time
-        let prescaler = (clock.frequency().0 / (2 * Hertz(20000000).0) - 1) as u8;
+        let prescaler = (clock.frequency() / (2 * 20_u32.MHz::<1, 1>()) - 1) as u8;
         adc.mr
             .modify(|_, w| unsafe { w.prescal().bits(prescaler).startup().sut80() });
 

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -2,7 +2,7 @@
 
 use cortex_m::peripheral::syst::SystClkSource;
 use cortex_m::peripheral::SYST;
-use embedded_time::rate::Hertz;
+use fugit::HertzU32 as Hertz;
 pub use hal::blocking::delay::{DelayMs, DelayUs};
 
 use crate::clock::*;
@@ -53,7 +53,7 @@ impl DelayUs<u32> for Delay {
         // The SysTick Reload Value register supports values between 1 and 0x00FFFFFF.
         const MAX_RVR: u32 = 0x00FF_FFFF;
 
-        let mut total_rvr = us * (self.sysclock.0 / 1_000_000);
+        let mut total_rvr = us * (self.sysclock.raw() / 1_000_000);
 
         while total_rvr != 0 {
             let current_rvr = if total_rvr <= MAX_RVR {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,11 +18,7 @@
 //!
 
 //#![deny(missing_docs)]
-//#![deny(warnings)]
 #![no_std]
-// Needed to quiet names such as NCS1 and UART0Clock (which now throw linting errors)
-// These errors seem to have been removed in nightly, so I suspect they may not stay.
-#![allow(clippy::upper_case_acronyms)]
 
 pub extern crate embedded_hal as hal;
 pub use hal::digital::v2::*;
@@ -78,8 +74,6 @@ pub use atsam4sd32c_pac as pac;
 
 use core::mem;
 
-pub use embedded_time as time;
-
 // NOTE: In ASF atsam4s uses sam/drivers/adc/adc.c whereas atsam4n uses sam/drivers/adc/adc2.c
 #[cfg(feature = "atsam4s")]
 pub mod adc;
@@ -98,6 +92,8 @@ pub mod timer;
 #[cfg(all(feature = "usb", any(feature = "atsam4e", feature = "atsam4s")))]
 pub mod udp;
 pub mod watchdog;
+
+mod sealed;
 
 /// Borrows a peripheral without checking if it has already been taken
 /// # Safety

--- a/src/sealed.rs
+++ b/src/sealed.rs
@@ -1,0 +1,48 @@
+#![allow(clippy::no_effect)]
+
+#[allow(dead_code)]
+#[allow(path_statements)]
+pub(crate) const fn not_one_or_two<const N: usize>() {
+    Assert::<N, 1>::NOT_EQ;
+    Assert::<N, 2>::NOT_EQ;
+}
+
+#[allow(dead_code)]
+#[allow(path_statements)]
+pub(crate) const fn smaller_than_or_eq<const N: usize, const MAX: usize>() {
+    Assert::<N, MAX>::LESS_EQ;
+}
+
+#[allow(dead_code)]
+#[allow(path_statements)]
+pub(crate) const fn equal<const N: usize, const M: usize>() {
+    Assert::<N, M>::EQ;
+}
+
+#[allow(dead_code)]
+pub struct Assert<const L: usize, const R: usize>;
+
+#[allow(dead_code)]
+impl<const L: usize, const R: usize> Assert<L, R> {
+    /// Const assert hack
+    pub const GREATER_EQ: usize = L - R;
+
+    /// Const assert hack
+    pub const LESS_EQ: usize = R - L;
+
+    /// Const assert hack
+    #[allow(clippy::erasing_op)]
+    pub const NOT_EQ: isize = 0 / (R as isize - L as isize);
+
+    /// Const assert hack
+    pub const EQ: usize = (R - L) + (L - R);
+
+    /// Const assert hack
+    pub const GREATER: usize = L - R - 1;
+
+    /// Const assert hack
+    pub const LESS: usize = R - L - 1;
+
+    /// Const assert hack
+    pub const POWER_OF_TWO: usize = 0 - (L & (L - 1));
+}

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -6,7 +6,6 @@ use {
     crate::gpio::{Pa10, Pa9, PfA},
     crate::pac::{UART0, UART1},
     core::marker::PhantomData,
-    embedded_time::rate::BitsPerSecond,
     hal::{serial::Read, serial::Write},
     paste::paste,
 };
@@ -72,12 +71,12 @@ macro_rules! uarts {
                         clock: [<$Uart Clock>]<Enabled>,
                         _rx_pin: $pin_rx,
                         _tx_pin: $pin_tx,
-                        baud_rate: BitsPerSecond,
+                        baud_rate: u32,
                         parity: Option<Parity>,
                     ) -> Self {
                         Self::reset_and_disable(&mut uart);
 
-                        let clock_divisor:u32 = (clock.frequency().0 / baud_rate.0) / 16;
+                        let clock_divisor:u32 = ((clock.frequency() / baud_rate) / 16).raw();
                         if !(1..=65535).contains(&clock_divisor) {
                             panic!("Unsupported baud_rate specified for serial device (cd = {})", clock_divisor);
                         }

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -9,7 +9,7 @@ use embedded_dma::{ReadBuffer, WriteBuffer};
 use paste::paste;
 
 pub use embedded_hal::spi;
-pub use embedded_time::rate::{Hertz, Kilohertz, Megahertz};
+pub use fugit::HertzU32 as Hertz;
 
 /// u8 that can convert back and forth with u16
 /// Needed for some of the register bit fields
@@ -176,7 +176,7 @@ impl ChipSelectSettings {
 
         // Calculate baud divider
         // (f_periph + baud - 1) / baud
-        let scbr = ((pclk.0 + baud.0 - 1) / baud.0) as u8;
+        let scbr = ((pclk.raw() + baud.raw() - 1) / baud.raw()) as u8;
         if scbr < 1 {
             panic!("scbr must be greater than 0: {}", scbr);
         }

--- a/src/udp/bus.rs
+++ b/src/udp/bus.rs
@@ -633,7 +633,7 @@ impl UsbBus for UdpBus {
 
         // Need to wait for the USB device to disconnect
         let freq = crate::clock::get_master_clock_frequency();
-        cortex_m::asm::delay(freq.0 / 1000); // 1 ms
+        cortex_m::asm::delay((freq / 1000).raw()); // 1 ms
 
         self._enable();
         Ok(())

--- a/src/udp/endpoint.rs
+++ b/src/udp/endpoint.rs
@@ -673,10 +673,10 @@ impl Endpoint {
     /// Note: USB bus implementation errors are directly passed through, so be prepared to handle
     /// other errors as well.
     ///
-    /// * [`WouldBlock`](crate::UsbError::WouldBlock) - The transmission buffer of the USB
+    /// * [`WouldBlock`](usb_device::UsbError::WouldBlock) - The transmission buffer of the USB
     ///   peripheral is full and the packet cannot be sent now. A peripheral may or may not support
     ///   concurrent transmission of packets.
-    /// * [`BufferOverflow`](crate::UsbError::BufferOverflow) - The data is longer than the
+    /// * [`BufferOverflow`](usb_device::UsbError::BufferOverflow) - The data is longer than the
     ///   `max_packet_size` specified when allocating the endpoint. This is generally an error in
     ///   the class implementation.
     pub fn write(&mut self, data: &[u8]) -> usb_device::Result<usize> {
@@ -761,10 +761,10 @@ impl Endpoint {
     /// Note: USB bus implementation errors are directly passed through, so be prepared to handle
     /// other errors as well.
     ///
-    /// * [`WouldBlock`](crate::UsbError::WouldBlock) - There is no packet to be read. Note that
+    /// * [`WouldBlock`](usb_device::UsbError::WouldBlock) - There is no packet to be read. Note that
     ///   this is different from a received zero-length packet, which is valid and significant in
     ///   USB. A zero-length packet will return `Ok(0)`.
-    /// * [`BufferOverflow`](crate::UsbError::BufferOverflow) - The received packet is too long to
+    /// * [`BufferOverflow`](usb_device::UsbError::BufferOverflow) - The received packet is too long to
     ///   fit in `data`. This is generally an error in the class implementation.
     pub fn read(&mut self, data: &mut [u8]) -> usb_device::Result<usize> {
         let csr = UDP::borrow_unchecked(|udp| udp.csr()[self.index as usize].read());


### PR DESCRIPTION
Fugit is a lot more straight-forward and allows for compile-time computation of clock dividers than embedded-time.

The api for RTT and TC timers has been simplified to use const generics when possible (as this allows for more compile-time computations).
Additional compile-time checks were added to prevent invalid settings (e.g. RTT prescaler can never be set to 1 or 2).