### PR TITLE
[TC] Fix clock enable for channels other than 0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atsam4-hal"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["John W. Terrell <john@coolpeoplenetworks.com>", "Jacob Alexander <haata@kiibohd.com>"]
 edition = "2021"
 description = "HAL for the ATSAM4 microcontrollers"


### PR DESCRIPTION
- Previous interface did not enable peripheral clock for channels other
  than TC0 channel 0
- Update api to require 3 enabled peripheral clocks per TC module
- Increment patch version